### PR TITLE
closes #252 - bugfix for Visualize_Poisson()

### DIFF
--- a/R/Visualize_Poisson.R
+++ b/R/Visualize_Poisson.R
@@ -22,7 +22,7 @@ Visualize_Poisson <- function( dfFlagged, dfBounds=NULL, strUnit="days"){
   p <- ggplot(
       dfFlagged,
       aes(
-        x=.data$LogExposure,
+        x=log(.data$TotalExposure),
         y=.data$TotalCount,
         color=as.factor(.data$Flag))
     ) +
@@ -43,7 +43,7 @@ Visualize_Poisson <- function( dfFlagged, dfBounds=NULL, strUnit="days"){
     ylab("Site Total Events") +
     geom_text(
         data = dfFlagged%>%filter(.data$Flag !=0),
-        aes( x = .data$LogExposure, y = .data$TotalCount, label = .data$SiteID),
+        aes( x = log(.data$TotalExposure), y = .data$TotalCount, label = .data$SiteID),
         vjust = 1.5,
         col="red",
         size=3.5

--- a/tests/testthat/test-AE_Visualize.R
+++ b/tests/testthat/test-AE_Visualize.R
@@ -1,3 +1,0 @@
-test_that("placeholder", {
-  expect_equal(2 * 2, 4)
-})

--- a/tests/testthat/test-Visualize_Poisson.R
+++ b/tests/testthat/test-Visualize_Poisson.R
@@ -1,0 +1,7 @@
+test_that("Output is produced", {
+  dfInput <- AE_Map_Adam( safetyData::adam_adsl, safetyData::adam_adae )
+  SafetyAE <- AE_Assess( dfInput , bDataList=TRUE, strMethod = "wilcoxon")
+  dfBounds <- Analyze_Poisson_PredictBounds(SafetyAE$dfTransformed, c(-5,5))
+
+  expect_silent(Visualize_Poisson(SafetyAE$dfFlagged, dfBounds))
+})


### PR DESCRIPTION
## Overview
`.data$LogExposure` becomes `log(.data$TotalExposure)`

## Test Notes/Sample Code
```r
dfInput <- AE_Map_Adam( safetyData::adam_adsl, safetyData::adam_adae )
SafetyAE <- AE_Assess( dfInput , bDataList=TRUE)
dfBounds <- Analyze_Poisson_PredictBounds(SafetyAE$dfTransformed, c(-5,5))
Visualize_Poisson(SafetyAE$dfFlagged, dfBounds)
```

## Risk Assessment
<!--- Complete a Risk Assessment for this Pull Request-->
<!--- Provide a quick description of what was done and why the -->
<!--- risk level and mitigation strategies were chosen -->
<!--- Each mitigation strategy should be given a status before PR is merged --->
Risk: Low
Mitigation Strategy: 
- Qualification Testing - TBD
- Unit Testing - Included/TBD
- Code Review - Included via PR review
- QC Checklist - To be included with Release
- Automated Testing - Package Checks via GitHub Actions

