### PR TITLE
fix #264 - refactor assessment data object + update tests

### DIFF
--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -22,13 +22,9 @@
 #' Consent date later in time than the Randomization Date. 'N' in the summary represents the number of subjects in a study that meet one or more criteria. Sites
 #' With N greater than user specified `nThreshold` will be flagged.
 #'
-#'
-#'
 #' @param dfInput input data with one record per person and the following required columns: SubjectID, SiteID, Count.
 #' @param nThreshold Any sites where 'N' is greater than nThreshold will be flagged. Default value is 0.5, which flags any site with one or more subjects meeting any of the criteria.
 #' @param strLabel Assessment label.
-#' @param bDataList Should all assessment datasets be returned as a list? If False (the default), only the summary/finding data frame is returned.
-#'
 #'
 #' @examples
 #'
@@ -40,34 +36,30 @@
 #'
 #'Consent_Assess(dfInput)
 #'
-#'
-#'
-#' @return If `bDataList` is false (the default), the summary data frame (`dfSummary`) is returned. If `bDataList` is true, a list containing all data in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged` and `dfSummary`) is returned.
+#' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'
 #' @export
 
-Consent_Assess <- function( dfInput, nThreshold=0.5,  strLabel="", bDataList=FALSE){
+Consent_Assess <- function( dfInput, nThreshold=0.5,  strLabel=""){
 
   stopifnot(
     "dfInput is not a data.frame" = is.data.frame(dfInput),
     "strLabel is not character" = is.character(strLabel),
-    "bDataList is not logical" = is.logical(bDataList),
     "One or more of these columns: SubjectID, SiteID,and Count not found in dfInput"=all(c("SubjectID","SiteID", "Count") %in% names(dfInput)),
     "nThreshold must be numeric" = is.numeric(nThreshold),
     "nThreshold must be length 1" = length(nThreshold) ==1
   )
 
   lAssess <- list()
+  lAssess$strFunctionName <- deparse(sys.call()[1])
+  lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
   lAssess$dfInput <- dfInput
   lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = 'Count'  )
   lAssess$dfAnalyzed <-lAssess$dfTransformed %>% mutate(Estimate = .data$TotalCount)
   lAssess$dfFlagged <- gsm::Flag( lAssess$dfAnalyzed ,vThreshold = c(NA,nThreshold), strColumn = "TotalCount" )
   lAssess$dfSummary <- gsm::Summarize( lAssess$dfFlagged, strScoreCol="TotalCount", strAssessment="Main Consent", strLabel= strLabel)
 
-  if(bDataList){
-    return(lAssess)
-  } else {
-    return(lAssess$dfSummary)
-  }
+  return(lAssess)
+
 }
 

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -15,9 +15,9 @@
 #' - \code{\link{Transform_EventCount}} creates `dfTransformed`.
 #' - \code{\link{Flag}} creates `dfFlagged`.
 #' - \code{\link{Summarize}} creates `dfSummary`.
-#' 
+#'
 #' @section Statistical Assumptions:
-#' 
+#'
 #' This Assessment finds any sites where one or more subjects which have Inclusion / Exclusion data that is either missing or has inconsistent data recorded for
 #' inclusion / exclusion data. N' in the summary represents the number of subjects in a study that meet one or more criteria. Sites
 #' With N greater than user specified `nThreshold` will be flagged.
@@ -26,7 +26,6 @@
 #' @param dfInput input data with one record per person and the following required columns: SubjectID, SiteID, Count,
 #' @param nThreshold Any sites where 'N' is greater than nThreshold will be flagged. Default value is 0.5, which flags any site with one or more subjects meeting any of the criteria.
 #' @param strLabel Assessment label
-#' @param bDataList Should all assessment datasets be returned as a list? If False (the default), only the summary/finding data frame is returned
 #'
 #'
 #' @examples
@@ -43,33 +42,30 @@
 #' ie_summary <- IE_Assess(dfInput)
 #'
 #'
-#' @return If `bDataList` is false (the default), the summary data frame (`dfSummary`) is returned. If `bDataList` is true, a list containing all data in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged` and `dfSummary`) is returned.
+#' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'
 #' @export
 
-IE_Assess <- function( dfInput, nThreshold=0.5,  strLabel="", bDataList=FALSE){
+IE_Assess <- function(dfInput, nThreshold=0.5, strLabel=""){
 
   stopifnot(
     "dfInput is not a data.frame" = is.data.frame(dfInput),
     "strLabel is not character" = is.character(strLabel),
-    "bDataList is not logical" = is.logical(bDataList),
     "One or more of these columns: SubjectID, SiteID, Count, Exposure, and Rate not found in dfInput"=all(c("SubjectID","SiteID", "Count") %in% names(dfInput)),
     "nThreshold must be numeric" = is.numeric(nThreshold),
     "nThreshold must be length 1" = length(nThreshold) ==1
   )
 
-
   lAssess <- list()
+  lAssess$strFunctionName <- deparse(sys.call()[1])
+  lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
   lAssess$dfInput <- dfInput
   lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = "Count")
   lAssess$dfAnalyzed <-lAssess$dfTransformed %>% mutate(Estimate = .data$TotalCount)
   lAssess$dfFlagged <- gsm::Flag( lAssess$dfAnalyzed , vThreshold = c(NA,nThreshold), strColumn = "Estimate" )
   lAssess$dfSummary <- gsm::Summarize( lAssess$dfFlagged, strScoreCol="TotalCount", strAssessment="Inclusion/Exclusion", strLabel= strLabel)
 
-  if(bDataList){
-    return(lAssess)
-  } else {
-    return(lAssess$dfSummary)
-  }
+  return(lAssess)
+
 }
 

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -9,11 +9,11 @@
 #' The input data (`dfInput`) for the PD Assessment is typically created using \code{\link{PD_Map_Raw}} and should be one record per person with columns for:
 #' - `SubjectID` - Unique subject ID
 #' - `SiteID` - Site ID
-#' - `Count` - Number of protocol deviation events 
-#' - `Exposure` - Number of days of exposure 
+#' - `Count` - Number of protocol deviation events
+#' - `Exposure` - Number of days of exposure
 #' - `Rate` - Rate of Exposure (Count / Exposure)
-#' 
-#' The Assessment 
+#'
+#' The Assessment
 #' - \code{\link{Transform_EventCount}} creates `dfTransformed`.
 #' - \code{\link{Analyze_Poisson}} or \code{\link{Analyze_Wilcoxon}} creates `dfAnalyzed`.
 #' - \code{\link{Flag}} creates `dfFlagged`.
@@ -29,28 +29,29 @@
 #' @param vThreshold list of threshold values default c(-5,5) for method = "poisson", c(.0001,NA) for method = Wilcoxon
 #' @param strLabel Assessment label
 #' @param strMethod valid methods are "poisson" (the default), or  "wilcoxon"
-#' @param bDataList Should all assessment datasets be returned as a list? If False (the default), only the finding data frame is returned
 #'
 #' @examples
 #' dfInput <- PD_Map_Raw(dfPD = clindata::raw_protdev, dfRDSL = clindata::rawplus_rdsl)
 #' SafetyPD <- PD_Assess( dfInput )
 #' SafetyPD_Wilk <- PD_Assess( dfInput, strMethod="wilcoxon")
 #'
-#' @return If `bDataList` is false (the default), the summary data frame (`dfSummary`) is returned. If `bDataList` is true, a list containing all data in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged` and `dfSummary`) is returned.
+#' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'
 #' @export
-PD_Assess <- function( dfInput, vThreshold=NULL, strLabel="",strMethod="poisson", bDataList=FALSE){
+
+PD_Assess <- function(dfInput, vThreshold=NULL, strLabel="",strMethod="poisson"){
     stopifnot(
         "dfInput is not a data.frame" = is.data.frame(dfInput),
         "strLabel is not character" = is.character(strLabel),
         "Length of strLabel is not greater than 1" = length(strLabel) <=1 ,
         "strMethod is not 'poisson' or 'wilcoxon'" = strMethod %in% c("poisson","wilcoxon"),
         "strMethod must be length 1" = length(strMethod) == 1,
-        "bDataList is not logical" = is.logical(bDataList),
         "One or more of these columns: SubjectID, SiteID, Count, Exposure, and Rate not found in dfInput"=all(c("SubjectID","SiteID", "Count","Exposure", "Rate") %in% names(dfInput))
     )
 
     lAssess <- list()
+    lAssess$strFunctionName <- deparse(sys.call()[1])
+    lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
     lAssess$dfInput <- dfInput
     lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = "Count", strExposureCol = "Exposure")
 
@@ -85,9 +86,6 @@ PD_Assess <- function( dfInput, vThreshold=NULL, strLabel="",strMethod="poisson"
         lAssess$dfSummary <- gsm::Summarize( lAssess$dfFlagged, strAssessment="Safety", strLabel= strLabel)
     }
 
-    if(bDataList){
-        return(lAssess)
-    } else {
-        return(lAssess$dfSummary)
-    }
+    return(lAssess)
+
 }

--- a/R/Visualize_Count.R
+++ b/R/Visualize_Count.R
@@ -17,7 +17,7 @@
 #'    vExpectedResultValues=c(0,1)
 #')
 #'
-#' ie_assess <- IE_Assess(ie_input, bDataList=TRUE)
+#' ie_assess <- IE_Assess(ie_input)
 #' Visualize_Count(ie_assess$dfAnalyzed)
 #'
 #' consent_input <- Consent_Map_Raw(
@@ -26,7 +26,7 @@
 #'   strConsentReason = NULL
 #' )
 #'
-#' consent_assess <- Consent_Assess(consent_input, bDataList=TRUE)
+#' consent_assess <- Consent_Assess(consent_input)
 #' Visualize_Count(consent_assess$dfAnalyzed)
 #'
 #' @import ggplot2

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -4,7 +4,7 @@
 \alias{Consent_Assess}
 \title{Consent Assessment}
 \usage{
-Consent_Assess(dfInput, nThreshold = 0.5, strLabel = "", bDataList = FALSE)
+Consent_Assess(dfInput, nThreshold = 0.5, strLabel = "")
 }
 \arguments{
 \item{dfInput}{input data with one record per person and the following required columns: SubjectID, SiteID, Count.}
@@ -12,11 +12,9 @@ Consent_Assess(dfInput, nThreshold = 0.5, strLabel = "", bDataList = FALSE)
 \item{nThreshold}{Any sites where 'N' is greater than nThreshold will be flagged. Default value is 0.5, which flags any site with one or more subjects meeting any of the criteria.}
 
 \item{strLabel}{Assessment label.}
-
-\item{bDataList}{Should all assessment datasets be returned as a list? If False (the default), only the summary/finding data frame is returned.}
 }
 \value{
-If \code{bDataList} is false (the default), the summary data frame (\code{dfSummary}) is returned. If \code{bDataList} is true, a list containing all data in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged} and \code{dfSummary}) is returned.
+A list containing all data and metadata in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged}, \code{dfSummary}, \code{strFunctionName}, and \code{lParams}) is returned.
 }
 \description{
 Consent Assessment
@@ -59,7 +57,5 @@ strConsentReason = NULL
 )
 
 Consent_Assess(dfInput)
-
-
 
 }

--- a/man/IE_Assess.Rd
+++ b/man/IE_Assess.Rd
@@ -4,7 +4,7 @@
 \alias{IE_Assess}
 \title{Inclusion/Exclusion Assessment}
 \usage{
-IE_Assess(dfInput, nThreshold = 0.5, strLabel = "", bDataList = FALSE)
+IE_Assess(dfInput, nThreshold = 0.5, strLabel = "")
 }
 \arguments{
 \item{dfInput}{input data with one record per person and the following required columns: SubjectID, SiteID, Count,}
@@ -12,11 +12,9 @@ IE_Assess(dfInput, nThreshold = 0.5, strLabel = "", bDataList = FALSE)
 \item{nThreshold}{Any sites where 'N' is greater than nThreshold will be flagged. Default value is 0.5, which flags any site with one or more subjects meeting any of the criteria.}
 
 \item{strLabel}{Assessment label}
-
-\item{bDataList}{Should all assessment datasets be returned as a list? If False (the default), only the summary/finding data frame is returned}
 }
 \value{
-If \code{bDataList} is false (the default), the summary data frame (\code{dfSummary}) is returned. If \code{bDataList} is true, a list containing all data in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged} and \code{dfSummary}) is returned.
+A list containing all data and metadata in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged}, \code{dfSummary}, \code{strFunctionName}, and \code{lParams}) is returned.
 }
 \description{
 Inclusion/Exclusion Assessment

--- a/man/PD_Assess.Rd
+++ b/man/PD_Assess.Rd
@@ -4,13 +4,7 @@
 \alias{PD_Assess}
 \title{Protocol Deviation Assessment}
 \usage{
-PD_Assess(
-  dfInput,
-  vThreshold = NULL,
-  strLabel = "",
-  strMethod = "poisson",
-  bDataList = FALSE
-)
+PD_Assess(dfInput, vThreshold = NULL, strLabel = "", strMethod = "poisson")
 }
 \arguments{
 \item{dfInput}{input data with one record per person and the following required columns: SubjectID, SiteID, Count, Exposure, Rate.}
@@ -20,11 +14,9 @@ PD_Assess(
 \item{strLabel}{Assessment label}
 
 \item{strMethod}{valid methods are "poisson" (the default), or  "wilcoxon"}
-
-\item{bDataList}{Should all assessment datasets be returned as a list? If False (the default), only the finding data frame is returned}
 }
 \value{
-If \code{bDataList} is false (the default), the summary data frame (\code{dfSummary}) is returned. If \code{bDataList} is true, a list containing all data in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged} and \code{dfSummary}) is returned.
+A list containing all data and metadata in the standard data pipeline (\code{dfInput}, \code{dfTransformed}, \code{dfAnalyzed}, \code{dfFlagged}, \code{dfSummary}, \code{strFunctionName}, and \code{lParams}) is returned.
 }
 \description{
 Protocol Deviation Assessment

--- a/man/Visualize_Count.Rd
+++ b/man/Visualize_Count.Rd
@@ -36,7 +36,7 @@ ie_input <- IE_Map_Raw(
    vExpectedResultValues=c(0,1)
 )
 
-ie_assess <- IE_Assess(ie_input, bDataList=TRUE)
+ie_assess <- IE_Assess(ie_input)
 Visualize_Count(ie_assess$dfAnalyzed)
 
 consent_input <- Consent_Map_Raw(
@@ -45,7 +45,7 @@ consent_input <- Consent_Map_Raw(
   strConsentReason = NULL
 )
 
-consent_assess <- Consent_Assess(consent_input, bDataList=TRUE)
+consent_assess <- Consent_Assess(consent_input)
 Visualize_Count(consent_assess$dfAnalyzed)
 
 }

--- a/tests/testthat/test-Visualize_Count.R
+++ b/tests/testthat/test-Visualize_Count.R
@@ -23,7 +23,7 @@ ie_input <- IE_Map_Raw(
 
 
 test_that("output is produced with consent data", {
-consent_assess <- Consent_Assess(consent_input, bDataList=TRUE)
+consent_assess <- Consent_Assess(consent_input)
 
 expect_silent(
   Visualize_Count(consent_assess$dfAnalyzed)
@@ -31,7 +31,7 @@ expect_silent(
 })
 
 test_that("output is produced with IE data", {
-  ie_assess <- IE_Assess(ie_input, bDataList=TRUE)
+  ie_assess <- IE_Assess(ie_input)
 
   expect_silent(
     Visualize_Count(ie_assess$dfAnalyzed)
@@ -39,8 +39,8 @@ test_that("output is produced with IE data", {
 })
 
 test_that("incorrect inputs throw errors",{
-  consent_assess <- Consent_Assess(consent_input, bDataList=TRUE)
-  ie_assess <- IE_Assess(ie_input, bDataList=TRUE)
+  consent_assess <- Consent_Assess(consent_input)
+  ie_assess <- IE_Assess(ie_input)
 
   expect_error(Visualize_Count(list()))
   expect_error(Visualize_Count("Hi"))

--- a/tests/testthat/test_IE_Assess.R
+++ b/tests/testthat/test_IE_Assess.R
@@ -4,23 +4,30 @@
 ie_input <- suppressWarnings(IE_Map_Raw(clindata::raw_ie_all , clindata::rawplus_rdsl, strCategoryCol = 'IECAT_STD', strResultCol = 'IEORRES'))
 
 
-test_that("summary df created as expected and has correct structure",{
+test_that("output is created as expected",{
     ie_list <- IE_Assess(ie_input)
-    expect_true(is.data.frame(ie_list))
-    expect_equal(names(ie_list),c("Assessment","Label", "SiteID", "N", "Score", "Flag"))
+    expect_true(is.list(ie_list))
+    expect_equal(names(ie_list),c("strFunctionName", "lParams", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary"))
+    expect_true("data.frame" %in% class(ie_list$dfInput))
+    expect_true("data.frame" %in% class(ie_list$dfTransformed))
+    expect_true("data.frame" %in% class(ie_list$dfAnalyzed))
+    expect_true("data.frame" %in% class(ie_list$dfFlagged))
+    expect_true("data.frame" %in% class(ie_list$dfSummary))
+    expect_type(ie_list$strFunctionName, "character")
+    expect_type(ie_list$lParams, "list")
 })
 
-test_that("list of df created when bDataList=TRUE",{
-    ie_list <- IE_Assess(ie_input, bDataList=TRUE)
-    expect_true(is.list(ie_list))
-    expect_equal(names(ie_list),c('dfInput','dfTransformed','dfAnalyzed','dfFlagged','dfSummary'))
+test_that("correct function and params are returned", {
+  ie_list <- IE_Assess(ie_input, nThreshold = 0.755555, strLabel = "nice label!")
+  expect_equal("IE_Assess()", ie_list$strFunctionName)
+  expect_equal("0.755555", ie_list$lParams$nThreshold)
+  expect_equal("nice label!", ie_list$lParams$strLabel)
 })
 
 test_that("incorrect inputs throw errors",{
     expect_error(IE_Assess(list()))
     expect_error(IE_Assess("Hi"))
     expect_error(IE_Assess(ie_input, strLabel=123))
-    expect_error(IE_Assess(ie_input, bDataList="Yes"))
     expect_error(IE_Assess(ie_input, nThreshold=FALSE))
     expect_error(IE_Assess(ie_input, nThreshold="A"))
     expect_error(IE_Assess(ie_input, nThreshold=c(1,2)))
@@ -42,7 +49,7 @@ ie_input1 <- tibble::tribble(        ~SubjectID, ~SiteID, ~Count,
                                          "1032", "X033X",     9L
                                      )
 
-ie_summary <- IE_Assess(ie_input1, bDataList=FALSE)
+ie_summary <- IE_Assess(ie_input1)
 
 
 target_ie_summary <- tibble::tribble(    ~Assessment, ~Label, ~SiteID, ~N, ~Score, ~Flag,
@@ -60,20 +67,20 @@ target_ie_summary_NA_SiteID <- tibble::tribble(    ~Assessment, ~Label, ~SiteID,
 
 
 test_that("output is correct given example input",{
-  expect_equal(ie_summary,target_ie_summary)
+  expect_equal(ie_summary$dfSummary,target_ie_summary)
 })
 
 
 test_that("NA in dfInput$SubjectID does not affect resulting dfSummary output for IE_Assess",{
   ie_input_in <- ie_input1; ie_input_in[1:2,"SubjectID"] = NA
-  ie_summary <- IE_Assess(ie_input_in, bDataList=FALSE)
-  expect_equal(ie_summary,target_ie_summary)
+  ie_summary <- IE_Assess(ie_input_in)
+  expect_equal(ie_summary$dfSummary,target_ie_summary)
 })
 
 test_that("NA in dfInput$SiteID results in NA for SiteID in dfSummary output for IE_Assess",{
   ie_input_in <- ie_input1; ie_input_in[1,"SiteID"] = NA
-  ie_summary <- IE_Assess(ie_input_in, bDataList=FALSE)
-  expect_equal(ie_summary,target_ie_summary_NA_SiteID)
+  ie_summary <- IE_Assess(ie_input_in)
+  expect_equal(ie_summary$dfSummary,target_ie_summary_NA_SiteID)
 })
 
 test_that("NA in dfInput$Count results in Error for IE_Assess",{

--- a/tests/testthat/test_PD_Assess.R
+++ b/tests/testthat/test_PD_Assess.R
@@ -1,24 +1,37 @@
 rdsl<-clindata::rawplus_rdsl %>% filter(RandFlag=="Y")
 pd_input <- PD_Map_Raw(dfPD = clindata::raw_protdev,dfRDSL = rdsl)
 
-test_that("summary df created as expected and has correct structure",{
+test_that("output is created as expected",{
   pd_assessment <- PD_Assess(pd_input)
-  expect_true(is.data.frame(pd_assessment))
-  expect_equal(names(pd_assessment),c("Assessment","Label", "SiteID", "N", "Score", "Flag"))
+  expect_true(is.list(pd_assessment))
+  expect_equal(names(pd_assessment),c("strFunctionName", "lParams", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary"))
+  expect_true("data.frame" %in% class(pd_assessment$dfInput))
+  expect_true("data.frame" %in% class(pd_assessment$dfTransformed))
+  expect_true("data.frame" %in% class(pd_assessment$dfAnalyzed))
+  expect_true("data.frame" %in% class(pd_assessment$dfFlagged))
+  expect_true("data.frame" %in% class(pd_assessment$dfSummary))
+  expect_type(pd_assessment$strFunctionName, "character")
+  expect_type(pd_assessment$lParams, "list")
 })
 
-test_that("list of df created when bDataList=TRUE",{
-  pd_list <- PD_Assess(pd_input, bDataList=TRUE)
-  expect_true(is.list(pd_list))
-  expect_equal(names(pd_list),c('dfInput','dfTransformed','dfAnalyzed','dfFlagged','dfSummary'))
+
+
+test_that("correct function and params are returned", {
+  pd_assessment <- PD_Assess(pd_input, vThreshold = c(-5,5), strLabel = "a simple label", strMethod = "poisson")
+  expect_equal("PD_Assess()", pd_assessment$strFunctionName)
+  expect_equal("-5", pd_assessment$lParams$vThreshold[2])
+  expect_equal("5", pd_assessment$lParams$vThreshold[3])
+  expect_equal("a simple label", pd_assessment$lParams$strLabel)
 })
+
+
+
 
 test_that("incorrect inputs throw errors",{
   expect_error(PD_Assess(list()))
   expect_error(PD_Assess("Hi"))
   expect_error(PD_Assess(pd_input, strLabel=123))
   expect_error(PD_Assess(pd_input, strMethod="abacus"))
-  expect_error(PD_Assess(pd_input, bDataList="Yes"))
   expect_error(PD_Assess(pd_input %>% select(-SubjectID)))
   expect_error(PD_Assess(pd_input %>% select(-SiteID)))
   expect_error(PD_Assess(pd_input %>% select(-Count)))
@@ -30,23 +43,7 @@ test_that("incorrect inputs throw errors",{
   expect_error(PD_Assess(pd_input, strLabel = iris))
 })
 
-test_that("Confirm expected functionality for PD_Assess input strlabel ",{
-  rdsl<-clindata::rawplus_rdsl %>% filter(RandFlag=="Y")
-  pd_input <- PD_Map_Raw(dfPD = clindata::raw_protdev,dfRDSL = rdsl)
-  pd_summary_df <- PD_Assess(pd_input, strLabel = "test_label")
-  expect_equal(pd_summary_df[1,"Label", drop = TRUE], 'test_label')
-})
 
-test_that("Confirm expected functionality for PD_Assess input strMethod ",{
-  rdsl<-clindata::rawplus_rdsl %>% filter(RandFlag=="Y")
-  pd_input <- PD_Map_Raw(dfPD = clindata::raw_protdev,dfRDSL = rdsl)
-  pd_list <- PD_Assess(pd_input, strMethod = 'wilcoxon', bDataList = TRUE)
-  expect_true('PValue' %in% names(pd_list$dfAnalyzed))
-  pd_list <- PD_Assess(pd_input, strMethod = 'poisson', bDataList = TRUE)
-  pd_list$dfAnalyzed
-  expect_true('PredictedCount' %in% names(pd_list$dfAnalyzed))
-  
-})
 
 
 


### PR DESCRIPTION
## Overview
**Refactor `*_Assess()` functions to address specs in #264**
- returns `functionName` as character
- returns `params`, which returns the verbatim input(s) used to call `AE_Assess()` as a list
- `Disp_Assess()` #175 will need to be updated
- `AE_Assess()` was already covered in PR #267
- `bDataList` is retired 


## Risk Assessment
<!--- Complete a Risk Assessment for this Pull Request-->
<!--- Provide a quick description of what was done and why the -->
<!--- risk level and mitigation strategies were chosen -->
<!--- Each mitigation strategy should be given a status before PR is merged --->
Risk: Low
Mitigation Strategy: 
- Qualification Testing - Included/TBD
- Unit Testing - Included and updated
- Code Review - Included via PR review
- QC Checklist - To be included with Release
- Automated Testing - Package Checks via GitHub Actions

