### PR TITLE
Changed Assess examples (names of return values) to reflect new bahav…

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -35,7 +35,7 @@
 #' @examples
 #' dfInput <- AE_Map_Adam( safetyData::adam_adsl, safetyData::adam_adae )
 #' SafetyAE <- AE_Assess( dfInput )
-#' SafetyAE_Wilk <- AE_Assess( dfInput, strMethod="wilcoxon")
+#' SafetyAE_Wilk <- AE_Assess( dfInput, strMethod="wilcoxon")$dfSummary
 #'
 #' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -34,7 +34,7 @@
 #' strConsentReason = NULL
 #')
 #'
-#'Consent_Assess(dfInput)
+#' Consent_Summary <- Consent_Assess(dfInput)$dfSummary
 #'
 #' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -39,7 +39,7 @@
 #'    vExpectedResultValues=c(0,1)
 #')
 #'
-#' ie_summary <- IE_Assess(dfInput)
+#' IE_Summary <- IE_Assess(dfInput)$dfSummary
 #'
 #'
 #' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -33,7 +33,7 @@
 #' @examples
 #' dfInput <- PD_Map_Raw(dfPD = clindata::raw_protdev, dfRDSL = clindata::rawplus_rdsl)
 #' SafetyPD <- PD_Assess( dfInput )
-#' SafetyPD_Wilk <- PD_Assess( dfInput, strMethod="wilcoxon")
+#' SafetyPD_Wilk <- PD_Assess( dfInput, strMethod="wilcoxon")$dfSummary
 #'
 #' @return A list containing all data and metadata in the standard data pipeline (`dfInput`, `dfTransformed`, `dfAnalyzed`, `dfFlagged`, `dfSummary`, `strFunctionName`, and `lParams`) is returned.
 #'

--- a/man/AE_Assess.Rd
+++ b/man/AE_Assess.Rd
@@ -56,6 +56,6 @@ See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additio
 \examples{
 dfInput <- AE_Map_Adam( safetyData::adam_adsl, safetyData::adam_adae )
 SafetyAE <- AE_Assess( dfInput )
-SafetyAE_Wilk <- AE_Assess( dfInput, strMethod="wilcoxon")
+SafetyAE_Wilk <- AE_Assess( dfInput, strMethod="wilcoxon")$dfSummary
 
 }

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -56,6 +56,6 @@ dfRDSL = clindata::rawplus_rdsl,
 strConsentReason = NULL
 )
 
-Consent_Assess(dfInput)
+Consent_Summary <- Consent_Assess(dfInput)$dfSummary
 
 }

--- a/man/IE_Assess.Rd
+++ b/man/IE_Assess.Rd
@@ -59,7 +59,7 @@ dfInput <- IE_Map_Raw(
    vExpectedResultValues=c(0,1)
 )
 
-ie_summary <- IE_Assess(dfInput)
+IE_Summary <- IE_Assess(dfInput)$dfSummary
 
 
 }

--- a/man/PD_Assess.Rd
+++ b/man/PD_Assess.Rd
@@ -56,6 +56,6 @@ See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additio
 \examples{
 dfInput <- PD_Map_Raw(dfPD = clindata::raw_protdev, dfRDSL = clindata::rawplus_rdsl)
 SafetyPD <- PD_Assess( dfInput )
-SafetyPD_Wilk <- PD_Assess( dfInput, strMethod="wilcoxon")
+SafetyPD_Wilk <- PD_Assess( dfInput, strMethod="wilcoxon")$dfSummary
 
 }


### PR DESCRIPTION
…iour where parameter bDataList has been removed


## Overview

Changed examples in AE_Assess, PD_Assess, Consent_Assess, and IE_Assess to reflect new default behavior of Assess wrappers. (bDataList = BOOL has been removed, so now default is to return full list instead of just the summary df.  The examples still worked, previously, but the naming of the return values could be confusing.


## Risk Assessment
Non Existant.
Risk: Low/Medium/High
Mitigation Strategy: 
- Qualification Testing - [Included/Issue #X Filed]
- Unit Testing - [Included/Issue #X Filed]
- Code Review - [Included via PR review]
- QC Checklist - [To be included with Release/Included in Comment]
- Automated Testing - [Package Checks via GitHub Actions]


