### PR TITLE
Fix #324, correct typos in documentation

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -23,9 +23,9 @@
 #'
 #' @section Statistical Assumptions:
 #'
-#' A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the `strMethod` parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in `vThreshold`. In the Poisson model, sites with an estimand less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
+#' A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the `strMethod` parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in `vThreshold`. In the Poisson model, sites with an estimate less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
 #'
-#' See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and thier assumptions.
+#' See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and their assumptions.
 #'
 #' @param dfInput input data with one record per person and the following required columns: SubjectID, SiteID, Count, Exposure.
 #' @param vThreshold numeric vector with 2 threshold values.  Defaults to c(-5,5) for method = "poisson" and c(.0001,NA) for method = Wilcoxon.

--- a/R/Analyze_Poisson_PredictBounds.R
+++ b/R/Analyze_Poisson_PredictBounds.R
@@ -17,7 +17,7 @@
 #' - `TotalExposure` - Number of days of exposure
 #'
 #' @param dfTransformed data.frame in format produced by \code{\link{Transform_EventCount}}. Must include SubjectID, SiteID, TotalCount and TotalExposure.
-#' @param vThreshold upper and lower boundaries in residual space. Should be identical to the threhsolds used AE_Assess().
+#' @param vThreshold upper and lower boundaries in residual space. Should be identical to the thresholds used AE_Assess().
 #'
 #' @importFrom stats glm offset poisson pnorm
 #' @importFrom broom augment

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -18,7 +18,7 @@
 #'
 #' @section Statistical Assumptions:
 #'
-#' This Assessment finds any sites where one or more subjects meets any of the following citeria: No Consent, Missing Consent, Missing Randomization Date, or
+#' This Assessment finds any sites where one or more subjects meets any of the following criteria: No Consent, Missing Consent, Missing Randomization Date, or
 #' Consent date later in time than the Randomization Date. 'N' in the summary represents the number of subjects in a study that meet one or more criteria. Sites
 #' With N greater than user specified `nThreshold` will be flagged.
 #'

--- a/R/Flag.R
+++ b/R/Flag.R
@@ -8,7 +8,7 @@
 #'
 #' @section Data Specification:
 #'
-#' \code{Flag} is designed to support the input data (` dfAnalyzed`) input data from many different \code{Analyze} functions. At a minimum, the input data must have a `SiteID` column and a column of numeric values (identified by the `strColumn` parameter) that will be compared to the specified threhsolds (`vThreshold`) to calculate a new `Flag` column. Optionally, a second column of numeric values (identified by `strValueColumn`) can be specified to set the directionality of the `Flag`.
+#' \code{Flag} is designed to support the input data (` dfAnalyzed`) input data from many different \code{Analyze} functions. At a minimum, the input data must have a `SiteID` column and a column of numeric values (identified by the `strColumn` parameter) that will be compared to the specified thresholds (`vThreshold`) to calculate a new `Flag` column. Optionally, a second column of numeric values (identified by `strValueColumn`) can be specified to set the directionality of the `Flag`.
 #'
 #' In short, the following columns are considered:
 #' - `SiteID` - Site ID (required)
@@ -74,8 +74,8 @@ Flag <- function( dfAnalyzed , strColumn="PValue", vThreshold=c(0.05,NA),strValu
         TRUE ~ Flag
       ))
   }
-  
+
   dfFlagged <- dfFlagged  %>% arrange(match(.data$Flag, c(1, -1, 0)))
-  
+
   return( dfFlagged )
 }

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -21,9 +21,9 @@
 #'
 #' @section Statistical Assumptions:
 #'
-#' A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the `strMethod` parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in `vThreshold`. In the Poisson model, sites with an estimand less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
+#' A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the `strMethod` parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in `vThreshold`. In the Poisson model, sites with an estimate less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
 #'
-#' See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and thier assumptions.
+#' See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and their assumptions.
 #'
 #' @param dfInput input data with one record per person and the following required columns: SubjectID, SiteID, Count, Exposure, Rate.
 #' @param vThreshold list of threshold values default c(-5,5) for method = "poisson", c(.0001,NA) for method = Wilcoxon.

--- a/R/Transform_EventCount.R
+++ b/R/Transform_EventCount.R
@@ -22,7 +22,7 @@
 #' - `Exposure` - Number of days of exposure, name specified by strExposureCol.
 #'
 #'  The input data has one or more rows per site. Transform_EventCount sums strCountCol for a TotalCount for each site.
-#'  For data with an optional strExposureCol, a summed exposure is caculated for each site.
+#'  For data with an optional strExposureCol, a summed exposure is calculated for each site.
 #'
 #' @param dfInput A data.frame with one record per person.
 #' @param strCountCol Required. Numerical or logical. Column to be counted.

--- a/R/Visualize_Count.R
+++ b/R/Visualize_Count.R
@@ -2,7 +2,7 @@
 #'
 #' @param dfAnalyzed Map results from IE or Consent assessments.
 #' @param strTotalCol Column containing total of site-level participants. Default is "N" from \code{\link{Transform_EventCount}}.
-#' @param strCountCol Column containing total number of site-level occurances. Default is "TotalCount" from \code{\link{Transform_EventCount}}.
+#' @param strCountCol Column containing total number of site-level occurrences. Default is "TotalCount" from \code{\link{Transform_EventCount}}.
 #' @param strTitle Title of plot. NULL by default.
 #'
 #' @return site level plot object
@@ -21,7 +21,7 @@
 #' Visualize_Count(IE_Assess$dfAnalyzed)
 #'
 #' library(dplyr)
-#' raw_consent <- clindata::raw_ic_elig %>% 
+#' raw_consent <- clindata::raw_ic_elig %>%
 #'    select( c("SUBJID","DSSTDAT_RAW") )%>%
 #'    mutate( CONSCAT_STD = "MAINCONSENT", CONSYN="Y") %>%
 #'    rename( CONSDAT = DSSTDAT_RAW ) %>%

--- a/man/AE_Assess.Rd
+++ b/man/AE_Assess.Rd
@@ -53,9 +53,9 @@ The Assessment
 \section{Statistical Assumptions}{
 
 
-A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the \code{strMethod} parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in \code{vThreshold}. In the Poisson model, sites with an estimand less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
+A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the \code{strMethod} parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in \code{vThreshold}. In the Poisson model, sites with an estimate less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
 
-See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and thier assumptions.
+See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and their assumptions.
 }
 
 \examples{

--- a/man/Analyze_Poisson_PredictBounds.Rd
+++ b/man/Analyze_Poisson_PredictBounds.Rd
@@ -9,7 +9,7 @@ Analyze_Poisson_PredictBounds(dfTransformed, vThreshold = c(-5, 5))
 \arguments{
 \item{dfTransformed}{data.frame in format produced by \code{\link{Transform_EventCount}}. Must include SubjectID, SiteID, TotalCount and TotalExposure.}
 
-\item{vThreshold}{upper and lower boundaries in residual space. Should be identical to the threhsolds used AE_Assess().}
+\item{vThreshold}{upper and lower boundaries in residual space. Should be identical to the thresholds used AE_Assess().}
 }
 \value{
 data frame containing predicted boundary values with upper and lower bounds across the range of observed values

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -43,7 +43,7 @@ The Assessment
 \section{Statistical Assumptions}{
 
 
-This Assessment finds any sites where one or more subjects meets any of the following citeria: No Consent, Missing Consent, Missing Randomization Date, or
+This Assessment finds any sites where one or more subjects meets any of the following criteria: No Consent, Missing Consent, Missing Randomization Date, or
 Consent date later in time than the Randomization Date. 'N' in the summary represents the number of subjects in a study that meet one or more criteria. Sites
 With N greater than user specified \code{nThreshold} will be flagged.
 }

--- a/man/Flag.Rd
+++ b/man/Flag.Rd
@@ -32,7 +32,7 @@ This function provides a generalized framework for flagging sites as part of the
 \section{Data Specification}{
 
 
-\code{Flag} is designed to support the input data (\code{ dfAnalyzed}) input data from many different \code{Analyze} functions. At a minimum, the input data must have a \code{SiteID} column and a column of numeric values (identified by the \code{strColumn} parameter) that will be compared to the specified threhsolds (\code{vThreshold}) to calculate a new \code{Flag} column. Optionally, a second column of numeric values (identified by \code{strValueColumn}) can be specified to set the directionality of the \code{Flag}.
+\code{Flag} is designed to support the input data (\code{ dfAnalyzed}) input data from many different \code{Analyze} functions. At a minimum, the input data must have a \code{SiteID} column and a column of numeric values (identified by the \code{strColumn} parameter) that will be compared to the specified thresholds (\code{vThreshold}) to calculate a new \code{Flag} column. Optionally, a second column of numeric values (identified by \code{strValueColumn}) can be specified to set the directionality of the \code{Flag}.
 
 In short, the following columns are considered:
 \itemize{

--- a/man/PD_Assess.Rd
+++ b/man/PD_Assess.Rd
@@ -53,9 +53,9 @@ The Assessment
 \section{Statistical Assumptions}{
 
 
-A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the \code{strMethod} parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in \code{vThreshold}. In the Poisson model, sites with an estimand less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
+A Poisson or Wilcoxon model is used to generate estimates and p-values for each site (as specified with the \code{strMethod} parameter). Those model outputs are then used to flag possible outliers using the thresholds specified in \code{vThreshold}. In the Poisson model, sites with an estimate less than -5 are flagged as -1 and greater than 5 are flagged as 1 by default. For Wilcoxon, sites with p-values less than 0.0001 are flagged by default.
 
-See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and thier assumptions.
+See \code{\link{Analyze_Poisson}} and \code{\link{Analyze_Wilcoxon}} for additional details about the statistical methods and their assumptions.
 }
 
 \examples{

--- a/man/Transform_EventCount.Rd
+++ b/man/Transform_EventCount.Rd
@@ -42,7 +42,7 @@ Optional
 }
 
 The input data has one or more rows per site. Transform_EventCount sums strCountCol for a TotalCount for each site.
-For data with an optional strExposureCol, a summed exposure is caculated for each site.
+For data with an optional strExposureCol, a summed exposure is calculated for each site.
 }
 
 \examples{

--- a/man/Visualize_Count.Rd
+++ b/man/Visualize_Count.Rd
@@ -16,7 +16,7 @@ Visualize_Count(
 
 \item{strTotalCol}{Column containing total of site-level participants. Default is "N" from \code{\link{Transform_EventCount}}.}
 
-\item{strCountCol}{Column containing total number of site-level occurances. Default is "TotalCount" from \code{\link{Transform_EventCount}}.}
+\item{strCountCol}{Column containing total number of site-level occurrences. Default is "TotalCount" from \code{\link{Transform_EventCount}}.}
 
 \item{strTitle}{Title of plot. NULL by default.}
 }
@@ -40,7 +40,7 @@ IE_Assess <- IE_Assess(IE_Input)
 Visualize_Count(IE_Assess$dfAnalyzed)
 
 library(dplyr)
-raw_consent <- clindata::raw_ic_elig \%>\% 
+raw_consent <- clindata::raw_ic_elig \%>\%
    select( c("SUBJID","DSSTDAT_RAW") )\%>\%
    mutate( CONSCAT_STD = "MAINCONSENT", CONSYN="Y") \%>\%
    rename( CONSDAT = DSSTDAT_RAW ) \%>\%

--- a/vignettes/gsm.Rmd
+++ b/vignettes/gsm.Rmd
@@ -20,4 +20,4 @@ library(gsm)
 
 Gilead Statistical Monitoring {gsm} R package
 
-The Gilead Statistical Monitoring or {gsm} R package provides a framework for statistical data monitoring using R and Shiny. The provides a framework that allows users to assess, visualize and explore clinical trial data, allowing users to detect issues at sites, identify the root cause and decide on the appropriate action. The package currently provides asessments for the following domains:
+The Gilead Statistical Monitoring or {gsm} R package provides a framework for statistical data monitoring using R and Shiny. The provides a framework that allows users to assess, visualize and explore clinical trial data, allowing users to detect issues at sites, identify the root cause and decide on the appropriate action. The package currently provides assessments for the following domains:


### PR DESCRIPTION
## Overview
Fix spelling typos in the docs as noted in #324 



## Test Notes/Sample Code
This code was helpful in creating the table found in #324:
```r
ignore <- 
  c("ADAE", "adam", "ADaM", "adsl", "ADSL", "AE", "AEs", 
     "Chisq",  "clindata", "CMD", "Codecov", 
    "CONSCAT", "CONSDAT", "CONSYN", "DCREASCD", "df", "dfADAE", "dfAE", 
    "dfConsent", "dfDisp", "dfDomain", "dfFlagged", "dfIE", "dfRDSL", 
    "dfSubject", "dfTransformed", "directionality", "Disp",  
    "EventCount", "IDCol", "ie", "IECAT", "IEORRES", "lTags", "mainconsent", 
    "mergeSubjects", "na", "NaN", "nThreshold", "poisson", 
    "PredictedCount", "Pvalue", "PValue", "RandDate", "RDSL", "safetyData", 
    "SiteID", "SITEID", "strCategoryCol", "strCol", "strColumn", 
    "strCountCol", "strExposureCol", "strReason", "strResultCol", 
    "strValueColumn", "SubjectID", "SUBJID",   
    "ThresholdCol", "ThresholdHigh", "ThresholdLow", "TimeOnStudy", 
    "TimeOnTreatment", "TotalCount", "TotalExposure", "TRTEDT", "TRTSDT", 
    "USUBJID", "vThreshold", "wilcoxon")

devtools::spell_check() %>% 
  unnest(cols = found) %>% 
  filter(!word %in% ignore) %>% 
  gt::gt() %>% 
  gt::as_raw_html()
```

## Risk Assessment
<!--- Complete a Risk Assessment for this Pull Request-->
<!--- Provide a quick description of what was done and why the -->
<!--- risk level and mitigation strategies were chosen -->
<!--- Each mitigation strategy should be given a status before PR is merged --->
Risk: Low
Mitigation Strategy: N/A

Notes: Just updating spelling in docs so risk is nonexistent; mitigation strategy not needed.

