### PR TITLE
Fix #322, slight refactor for list creation in assess functions

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -57,12 +57,15 @@ AE_Assess <- function(dfInput, vThreshold=NULL, strMethod="poisson", lTags=list(
         )
     }
 
-    lAssess <- list()
-    lAssess$strFunctionName <- deparse(sys.call()[1])
-    lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
-    lAssess$lTags <- lTags
-    lAssess$dfInput <- dfInput
+    lAssess <- list(
+        strFunctionName = deparse(sys.call()[1]),
+        lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+        lTags = lTags,
+        dfInput = dfInput
+    )
+
     lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = 'Count', strExposureCol = "Exposure" )
+
     if(strMethod == "poisson"){
         if(is.null(vThreshold)){
             vThreshold = c(-5,5)

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -70,11 +70,13 @@ Consent_Assess <- function( dfInput, nThreshold=0.5,  lTags=list(Assessment="Con
       )
   }
 
-  lAssess <- list()
-  lAssess$strFunctionName <- deparse(sys.call()[1])
-  lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
-  lAssess$lTags <- lTags
-  lAssess$dfInput <- dfInput
+  lAssess <- list(
+    strFunctionName = deparse(sys.call()[1]),
+    lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+    lTags = lTags,
+    dfInput = dfInput
+  )
+
   lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = 'Count'  )
   lAssess$dfAnalyzed <-lAssess$dfTransformed %>% mutate(Estimate = .data$TotalCount)
   lAssess$dfFlagged <- gsm::Flag( lAssess$dfAnalyzed ,vThreshold = c(NA,nThreshold), strColumn = "TotalCount" )

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -61,16 +61,19 @@ IE_Assess <- function(dfInput, nThreshold=0.5, lTags=list(Assessment="IE")){
       )
   }
 
-  lAssess <- list()
-  lAssess$strFunctionName <- deparse(sys.call()[1])
-  lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
-  lAssess$lTags <- lTags
-  lAssess$dfInput <- dfInput
+  lAssess <- list(
+    strFunctionName = deparse(sys.call()[1]),
+    lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+    lTags = lTags,
+    dfInput = dfInput
+  )
+
   lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = "Count")
   lAssess$dfAnalyzed <-lAssess$dfTransformed %>% mutate(Estimate = .data$TotalCount)
   lAssess$dfFlagged <- gsm::Flag( lAssess$dfAnalyzed , vThreshold = c(NA,nThreshold), strColumn = "Estimate" )
   lAssess$dfSummary <- gsm::Summarize( lAssess$dfFlagged, strScoreCol="TotalCount", lTags)
 
   return(lAssess)
+
 }
 

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -58,11 +58,13 @@ PD_Assess <- function(dfInput, vThreshold=NULL,strMethod="poisson", lTags=list(A
         )
     }
 
-    lAssess <- list()
-    lAssess$strFunctionName <- deparse(sys.call()[1])
-    lAssess$lParams <- lapply(as.list(match.call()[-1]), function(x) as.character(x))
-    lAssess$lTags <- lTags
-    lAssess$dfInput <- dfInput
+    lAssess <- list(
+        strFunctionName = deparse(sys.call()[1]),
+        lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+        lTags = lTags,
+        dfInput = dfInput
+    )
+
     lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = "Count", strExposureCol = "Exposure")
 
     if(strMethod == "poisson"){
@@ -97,4 +99,5 @@ PD_Assess <- function(dfInput, vThreshold=NULL,strMethod="poisson", lTags=list(A
     }
 
     return(lAssess)
+
 }


### PR DESCRIPTION
## Overview
- Very slight refactor for creating `list`s in `*_Assess()` functions.
- Will hopefully help with future dev work to initiate a framework/skeleton for `*_Assess()` functions.

## Test Notes/Sample Code
```r
    lAssess <- list(
        strFunctionName = deparse(sys.call()[1]),
        lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
        lTags = lTags,
        dfInput = dfInput
    )
```


## Risk Assessment
<!--- Complete a Risk Assessment for this Pull Request-->
<!--- Provide a quick description of what was done and why the -->
<!--- risk level and mitigation strategies were chosen -->
<!--- Each mitigation strategy should be given a status before PR is merged --->
Risk: Low
Mitigation Strategy: 
- Qualification Testing - Included/TBD
- Unit Testing - Included
- Code Review - Included via PR review
- QC Checklist - To be included with Release
- Automated Testing - Package Checks via GitHub Actions

