### PR TITLE
Fix #307 - add `is_mapping_valid` to `*_Assess()` functions

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -70,9 +70,9 @@ AE_Assess <- function(dfInput, vThreshold=NULL, strMethod="poisson", lTags=list(
     lAssess <- list(
         strFunctionName = deparse(sys.call()[1]),
         lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+        lCheck = lCheck,
         lTags = lTags,
-        dfInput = dfInput,
-        lCheck = lCheck
+        dfInput = dfInput
     )
 
     lAssess$dfTransformed <- gsm::Transform_EventCount( lAssess$dfInput, strCountCol = 'Count', strExposureCol = "Exposure" )

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -71,9 +71,19 @@ Consent_Assess <- function( dfInput, nThreshold=0.5,  lTags=list(Assessment="Con
       )
   }
 
+  lParamsCheck <- yaml::read_yaml(system.file("inst/assessments/assessments.yaml", package = 'gsm'))
+
+  lCheck <- is_mapping_valid(
+    df = dfInput,
+    mapping = lParamsCheck$dfCONSENT$mapping,
+    vRequiredParams = lParamsCheck$dfCONSENT$required,
+    vUniqueCols = lParamsCheck$dfCONSENT$unique
+  )
+
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
     lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+    lCheck = lCheck,
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -59,9 +59,19 @@ IE_Assess <- function(dfInput, nThreshold=0.5, lTags=list(Assessment="IE"), bCha
       )
   }
 
+  lParamsCheck <- yaml::read_yaml(system.file("inst/assessments/assessments.yaml", package = 'gsm'))
+
+  lCheck <- is_mapping_valid(
+    df = dfInput,
+    mapping = lParamsCheck$dfIE$mapping,
+    vRequiredParams = lParamsCheck$dfIE$required,
+    vUniqueCols = lParamsCheck$dfIE$unique
+  )
+
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
     lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+    lCheck = lCheck,
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -59,9 +59,19 @@ PD_Assess <- function(dfInput, vThreshold=NULL,strMethod="poisson", lTags=list(A
         )
     }
 
+    lParamsCheck <- yaml::read_yaml(system.file("inst/assessments/assessments.yaml", package = 'gsm'))
+
+    lCheck <- is_mapping_valid(
+        df = dfInput,
+        mapping = lParamsCheck$dfPD$mapping,
+        vRequiredParams = lParamsCheck$dfPD$required,
+        vUniqueCols = lParamsCheck$dfPD$unique
+    )
+
     lAssess <- list(
         strFunctionName = deparse(sys.call()[1]),
         lParams = lapply(as.list(match.call()[-1]), function(x) as.character(x)),
+        lCheck = lCheck,
         lTags = lTags,
         dfInput = dfInput
     )

--- a/R/util-is_mapping_valid.R
+++ b/R/util-is_mapping_valid.R
@@ -100,7 +100,6 @@ is_mapping_valid <- function(
         tests_if$has_expected_columns$status <- TRUE
     }
 
-
 # Remaining checks only runs if all expected columns are found
 # If expected columns are missing, check status is FALSE and with a "check not run" warning.
 if (tests_if$has_expected_columns$status) {

--- a/inst/assessments/assessments.yaml
+++ b/inst/assessments/assessments.yaml
@@ -10,4 +10,43 @@ dfAE:
   - "strSiteCol"
   unique:
   - "strIDCol"
+dfCONSENT:
+  mapping:
+    strIDCol: "SubjectID"
+    strSiteCol: "SiteID"
+    strCountCol: "Count"
+  required:
+  - "strIDCol"
+  - "strSiteCol"
+  - "strCountCol"
+  unique:
+  - "strIDCol"
+dfIE:
+  mapping:
+    strIDCol: "SubjectID"
+    strSiteCol: "SiteID"
+    strCountCol: "Count"
+  required:
+  - "strIDCol"
+  - "strSiteCol"
+  - "strCountCol"
+  unique:
+  - "strIDCol"
+dfPD:
+  mapping:
+    strIDCol: "SubjectID"
+    strSiteCol: "SiteID"
+    strCountCol: "Count"
+    strExposureCol: "Exposure"
+    strRateCol: "Rate"
+  required:
+  - "strIDCol"
+  - "strSiteCol"
+  - "strExposureCol"
+  - "strCountCol"
+  - "strRateCol"
+  unique:
+  - "strIDCol"
+
+
 


### PR DESCRIPTION
## Overview
Took a pass at a solution for #307
- Uses a `yaml` file for default mappings
- Could add a solution for configurable mappings now or later

## Test Notes/Sample Code
@jwildfire all unit tests will fail because the output of `Assess` functions would change, but would be great if you could take an initial review to see if it's worth implementing.



