### PR TITLE
cli for is_mapping_valid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: file LICENSE
 Encoding: UTF-8
 Imports:
     broom,
+    cli,
     dplyr,
     fontawesome,
     ggplot2,

--- a/R/util-is_mapping_valid.R
+++ b/R/util-is_mapping_valid.R
@@ -168,8 +168,8 @@ if (tests_if$has_expected_columns$status) {
     if (bQuiet == FALSE) {
         all_warnings <- tests_if %>% map(~.x$warning) %>% keep(~!is.na(.x))
         if (length(all_warnings) > 0) {
-            all_warnings <- paste(unlist(unname(all_warnings)), collapse = "\n")
-            message(all_warnings)
+           all_warnings <- unlist(unname(all_warnings))
+           x <- map(all_warnings, ~cli::cli_alert_danger(cli::col_br_yellow(.)))
         }
     }
 


### PR DESCRIPTION
## Overview
- Adds `{cli}` for `is_mapping_valid()` when `bQuiet == FALSE`

![image](https://user-images.githubusercontent.com/40671730/163823263-27de53c5-f1cf-4e98-87bf-6f7e079a64d9.png)


## Test Notes/Sample Code
```r
df <- clindata::rawplus_subj
df$SubjectID[1] <- df$SubjectID[2]
df$SiteID <- NULL

a <- is_mapping_valid(df = df,
                 mapping = subj_mapping,
                 vUniqueCols = "strIDCol",
                 vRequiredParams = c("strIDCol", "strSiteCol", "strExposureCol"), 
                 bQuiet = FALSE)
```

Notes: holding off on updating `RunAssessment` until we know if using the original or recently refactored version

