### PR TITLE
Fix #391 - remove listed IDs from MergeSubjects

### DIFF
--- a/R/util-MergeSubjects.R
+++ b/R/util-MergeSubjects.R
@@ -56,11 +56,9 @@ MergeSubjects <- function(dfDomain, dfSubjects, strIDCol="SubjectID", vFillZero=
             paste0(
               cli::col_br_red(
                 length(domain_only_ids),
-                cli::col_br_red(" ID(s) in domain data not found in subject data: ")),
-                paste(domain_only_ids, collapse=" "),
-                ". ",
-                cli::col_br_red("Associated rows will not be included in merged data.\n")
+                cli::col_br_red(" ID(s) in domain data not found in subject data.\nAssociated rows will not be included in merged data.")
             )
+          )
         )
     }
 
@@ -72,16 +70,14 @@ MergeSubjects <- function(dfDomain, dfSubjects, strIDCol="SubjectID", vFillZero=
                 paste0(
                   cli::col_br_red(
                     length(subject_only_ids),
-                    " ID(s) in subject data not found in domain data: "),
-                    paste(subject_only_ids, collapse=" "),
-                    ". ",
+                    " ID(s) in subject data not found in domain data."),
                     ifelse(is.null(vFillZero),
-                        cli::col_br_red("These participants will have NA values imputed for all domain data columns:"),
+                          cli::col_br_red("These participants will have NA values imputed for all domain data columns:"),
                         paste0(
-                          cli::col_br_red("These participants will have 0s imputed for the following domain data columns: "),
+                          cli::col_br_red("\nThese participants will have 0s imputed for the following domain data columns: "),
                             paste(vFillZero, sep=", "),
                             ". ",
-                            cli::col_br_red("NA's will be imputed for all other columns.")
+                            cli::col_br_red("\nNA's will be imputed for all other columns.")
                         )
                     )
                 )

--- a/tests/testthat/_snaps/util_mergeSubjects.md
+++ b/tests/testthat/_snaps/util_mergeSubjects.md
@@ -3,8 +3,11 @@
     Code
       MergeSubjects(domain, subjects, vFillZero = "Count", bQuiet = F)
     Message <cliMessage>
-      ! 5 ID(s) in domain data not found in subject data: 0001 0002 0003 0004 0005. Associated rows will not be included in merged data.
-      ! 5 ID(s) in subject data not found in domain data: 0008 0009 0010 0011 0012. These participants will have 0s imputed for the following domain data columns: Count. NA's will be imputed for all other columns.
+      ! 5 ID(s) in domain data not found in subject data.
+      Associated rows will not be included in merged data.
+      ! 5 ID(s) in subject data not found in domain data.
+      These participants will have 0s imputed for the following domain data columns: Count. 
+      NA's will be imputed for all other columns.
     Output
       # A tibble: 6 x 4
         SubjectID SiteID Exposure Count


### PR DESCRIPTION
## Overview
Fix #391
- Minor change that removes `paste(domain_only_ids, collapse=" ")` for more concise error checking. 
- Discussed during scrum that we may want to have a `verbose` option to bring back list of IDs, or possible other implementations.

## Test Notes/Sample Code
`lAssessments <- Study_Assess()`

Previous: 
![image](https://user-images.githubusercontent.com/40671730/165365036-93fd6d35-ba57-4c1b-802d-f37cf23430cc.png)

Current:
![image](https://user-images.githubusercontent.com/40671730/165365128-21e5e0e6-01bd-4d9d-99e6-28d82965403a.png)



