### PR TITLE
fix #433 - view table option for `Study_AssessmentReport()`

### DIFF
--- a/R/Study_AssessmentReport.R
+++ b/R/Study_AssessmentReport.R
@@ -3,13 +3,14 @@
 #' Make overview table with one row per assessment and one column per site showing flagged assessments.
 #'
 #' @param lAssessments List of 1+ assessments like those created by `runAssessment()` or `Study_Assess()`
+#' @param bViewReport HTML table of dfSummary that can be viewed in most IDEs.
 #'
 #' @importFrom gt gt
 #' @importFrom fontawesome fa
 #'
 #' @return returns a list containing a data.frame summarizing the checks `dfSummary` and a dataframe listing all checks (`dfAllChecks``)
 
-Study_AssessmentReport <- function(lAssessments) {
+Study_AssessmentReport <- function(lAssessments, bViewReport = FALSE) {
 
 
   allChecks <- names(lAssessments) %>% map(function(assessment_name){
@@ -69,6 +70,10 @@ Study_AssessmentReport <- function(lAssessments) {
     dfSummary<- allChecks %>%
         mutate(check = map(check, rank_chg))
 
-    return(list(dfAllChecks = allChecks, dfSummary = dfSummary))
+    if(!bViewReport){
+      return(list(dfAllChecks = allChecks, dfSummary = dfSummary))
+    } else {
+      return(dfSummary %>% gt::gt())
+    }
 
 }

--- a/man/Study_AssessmentReport.Rd
+++ b/man/Study_AssessmentReport.Rd
@@ -4,10 +4,12 @@
 \alias{Study_AssessmentReport}
 \title{Make Summary of 1 or more assessment Data checks}
 \usage{
-Study_AssessmentReport(lAssessments)
+Study_AssessmentReport(lAssessments, bViewReport = FALSE)
 }
 \arguments{
 \item{lAssessments}{List of 1+ assessments like those created by \code{runAssessment()} or \code{Study_Assess()}}
+
+\item{bViewReport}{HTML table of dfSummary that can be viewed in most IDEs.}
 }
 \value{
 returns a list containing a data.frame summarizing the checks \code{dfSummary} and a dataframe listing all checks (`dfAllChecks``)

--- a/tests/testthat/test_Study_AssessmentReport.R
+++ b/tests/testthat/test_Study_AssessmentReport.R
@@ -38,3 +38,8 @@ test_that("Assessment Report fails with wrong input", {
     expect_error(Study_AssessmentReport(lAssessments = list()))
 })
 
+test_that("bViewReport works", {
+  lAssessments <- Study_Assess(lData = lData, bQuiet=TRUE)
+  view_true <- Study_AssessmentReport(lAssessments=lAssessments, bViewReport = TRUE)
+  expect_true("gt_tbl" %in% class(view_true))
+})


### PR DESCRIPTION
## Overview
Fix #433 
- Adds `bViewReport` option to `Study_AssessmentReport()` that is `FALSE` by default.

Notes: 
- Can add more styling or develop a template for `{gt}` tables in the future

