### PR TITLE
Fix #393 - re-implement `lSubjFilters` in `Study_Assess()`

### DIFF
--- a/R/Study_Assess.R
+++ b/R/Study_Assess.R
@@ -5,6 +5,7 @@
 #' @param lData a named list of domain level data frames. Names should match the values specified in `lMapping` and `lAssessments`, which are generally based on the expected inputs from `X_Map_Raw`.
 #' @param lMapping a named list identifying the columns needed in each data domain.
 #' @param lAssessments a named list of metadata defining how each assessment should be run. By default, `MakeAssessmentList()` imports YAML specifications from `inst/assessments`.
+#' @param lSubjFilters a named list of parameters to filter subject-level data on.
 #' @param lTags a named list of Tags to be passed to each assessment. Default is `list(Study="myStudy")` could be expanded to include other important metadata such as analysis population or study phase.
 #' @param bQuiet Default is TRUE, which means warning messages are suppressed. Set to FALSE to see warning messages.
 #'
@@ -48,24 +49,35 @@ Study_Assess <- function(
     if(is.null(lAssessments)){
         lAssessments <- MakeAssessmentList()
     }
-browser()
+
     # Filter data$dfSUBJ based on lSubjFilters --------------------------------
     if (!is.null(lSubjFilters)) {
       for (colMapping in names(lSubjFilters)) {
         if(!hasName(lMapping$dfSUBJ, colMapping)) {
           stop(paste0("`",colMapping, "` from lSubjFilters is not specified in lMapping$dfSUBJ"))
         }
-        col <- lMapping$dfSUBJ[[colMapping]]
+        col <- colMapping
         vals <- lSubjFilters[[colMapping]]
-        lData$dfSUBJ <- FilterDomain(df = lData$dfSUBJ, strDomain = 'dfSUBJ', lMapping = lMapping, strColParam = col, strValParam = vals, bQuiet = bQuiet)
+        lData$dfSUBJ <- FilterDomain(
+          df = lData$dfSUBJ,
+          strDomain = 'dfSUBJ',
+          lMapping = lMapping,
+          strColParam = col,
+          strValParam = vals,
+          bQuiet = bQuiet
+          )
       }
     }
 
-
+  if (nrow(lData$dfSUBJ > 0)) {
     ### --- Attempt to run each assessment --- ###
     lAssessments <- lAssessments %>% map(
         ~gsm::RunAssessment(.x, lData=lData, lMapping=lMapping, lTags=lTags, bQuiet=bQuiet)
     )
+  } else {
+    cli::cli_alert_danger("Subject-level data contains 0 rows. Assessment not run.")
+    lAssessments <- NULL
+  }
 
     return(lAssessments)
 }

--- a/man/AE_Map_Adam.Rd
+++ b/man/AE_Map_Adam.Rd
@@ -44,13 +44,13 @@ data (from \code{dfADSL}). Note that the function can generate data summaries fo
 AEs by passing filtered AE data to \code{dfADAE}.
 }
 \section{Data specification}{
-\tabular{llll}{
-   domain \tab col_key \tab col_value \tab vRequired \cr
-   dfADSL \tab strIDCol \tab USUBJID \tab TRUE \cr
-   dfADSL \tab strSiteCol \tab SITEID \tab TRUE \cr
-   dfADSL \tab strStartCol \tab TRTSDT \tab TRUE \cr
-   dfADSL \tab strEndCol \tab TRTEDT \tab TRUE \cr
-   dfADAE \tab strIDCol \tab USUBJID \tab TRUE \cr
+\tabular{lllll}{
+   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   dfADSL \tab strIDCol \tab USUBJID \tab TRUE \tab TRUE \cr
+   dfADSL \tab strSiteCol \tab SITEID \tab TRUE \tab FALSE \cr
+   dfADSL \tab strStartCol \tab TRTSDT \tab TRUE \tab FALSE \cr
+   dfADSL \tab strEndCol \tab TRTEDT \tab TRUE \tab FALSE \cr
+   dfADAE \tab strIDCol \tab USUBJID \tab TRUE \tab  \cr
 }
 }
 

--- a/man/AE_Map_Raw.Rd
+++ b/man/AE_Map_Raw.Rd
@@ -49,7 +49,7 @@ AEs by passing filtered AE data to \code{dfAE}.
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfSUBJ \tab strTimeOnTreatmentCol \tab TimeOnTreatment \tab TRUE \tab FALSE \cr
-   dfAE \tab strIDCol \tab SubjectID \tab TRUE \tab NA \cr
+   dfAE \tab strIDCol \tab SubjectID \tab TRUE \tab  \cr
 }
 }
 

--- a/man/Consent_Map_Raw.Rd
+++ b/man/Consent_Map_Raw.Rd
@@ -46,13 +46,13 @@ types of consent by customizing \code{lMapping$dfCONSENT}.
 \section{Data specification}{
 \tabular{llllll}{
    domain \tab col_key \tab col_value \tab vRequired \tab vNACols \tab vUniqueCols \cr
-   dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab NA \tab TRUE \cr
-   dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab NA \tab FALSE \cr
-   dfSUBJ \tab strRandDateCol \tab RandDate \tab TRUE \tab NA \tab FALSE \cr
-   dfCONSENT \tab strIDCol \tab SubjectID \tab TRUE \tab FALSE \tab NA \cr
-   dfCONSENT \tab strTypeCol \tab CONSENT_TYPE \tab TRUE \tab FALSE \tab NA \cr
-   dfCONSENT \tab strValueCol \tab CONSENT_VALUE \tab TRUE \tab FALSE \tab NA \cr
-   dfCONSENT \tab strDateCol \tab CONSENT_DATE \tab TRUE \tab TRUE \tab NA \cr
+   dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab  \tab TRUE \cr
+   dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab  \tab FALSE \cr
+   dfSUBJ \tab strRandDateCol \tab RandDate \tab TRUE \tab  \tab FALSE \cr
+   dfCONSENT \tab strIDCol \tab SubjectID \tab TRUE \tab FALSE \tab  \cr
+   dfCONSENT \tab strTypeCol \tab CONSENT_TYPE \tab TRUE \tab FALSE \tab  \cr
+   dfCONSENT \tab strValueCol \tab CONSENT_VALUE \tab TRUE \tab FALSE \tab  \cr
+   dfCONSENT \tab strDateCol \tab CONSENT_DATE \tab TRUE \tab TRUE \tab  \cr
 }
 }
 

--- a/man/IE_Map_Raw.Rd
+++ b/man/IE_Map_Raw.Rd
@@ -48,9 +48,9 @@ specific types of IE criteria by passing filtered IE data to \code{dfIE}.
    domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
-   dfIE \tab strIDCol \tab SubjectID \tab TRUE \tab NA \cr
-   dfIE \tab strCategoryCol \tab IE_CATEGORY \tab TRUE \tab NA \cr
-   dfIE \tab strValueCol \tab IE_VALUE \tab TRUE \tab NA \cr
+   dfIE \tab strIDCol \tab SubjectID \tab TRUE \tab  \cr
+   dfIE \tab strCategoryCol \tab IE_CATEGORY \tab TRUE \tab  \cr
+   dfIE \tab strValueCol \tab IE_VALUE \tab TRUE \tab  \cr
 }
 }
 

--- a/man/PD_Map_Raw.Rd
+++ b/man/PD_Map_Raw.Rd
@@ -49,7 +49,7 @@ PDs by passing filtered PD data to \code{dfPD}.
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfSUBJ \tab strTimeOnStudyCol \tab TimeOnStudy \tab TRUE \tab FALSE \cr
-   dfPD \tab strIDCol \tab SubjectID \tab TRUE \tab NA \cr
+   dfPD \tab strIDCol \tab SubjectID \tab TRUE \tab  \cr
 }
 }
 

--- a/man/Study_Assess.Rd
+++ b/man/Study_Assess.Rd
@@ -8,6 +8,7 @@ Study_Assess(
   lData = NULL,
   lMapping = NULL,
   lAssessments = NULL,
+  lSubjFilters = NULL,
   lTags = list(Study = "myStudy"),
   bQuiet = FALSE
 )
@@ -18,6 +19,8 @@ Study_Assess(
 \item{lMapping}{a named list identifying the columns needed in each data domain.}
 
 \item{lAssessments}{a named list of metadata defining how each assessment should be run. By default, \code{MakeAssessmentList()} imports YAML specifications from \code{inst/assessments}.}
+
+\item{lSubjFilters}{a named list of parameters to filter subject-level data on.}
 
 \item{lTags}{a named list of Tags to be passed to each assessment. Default is \code{list(Study="myStudy")} could be expanded to include other important metadata such as analysis population or study phase.}
 

--- a/tests/testthat/test_Study_Assess.R
+++ b/tests/testthat/test_Study_Assess.R
@@ -178,4 +178,25 @@ test_that("Map + Assess yields same result as Study_Assess()", {
   expect_equal(study_assess$pd$lResults$dfSummary[1:4], pd_assess$dfSummary[1:4])
 })
 
+test_that("lSubjFilters with 0 rows returns NULL", {
+
+  lMappingCustom <- clindata::mapping_rawplus
+
+  lMappingCustom$dfSUBJ$strSiteVal <- "XYZ"
+  lMappingCustom$dfSUBJ$strRandFlagVal <- "N"
+
+
+  tmp <- Study_Assess(
+    lData = lData,
+    lMapping = lMappingCustom,
+    lSubjFilters = list(strSiteCol = "strSiteVal",
+                        strSiteCol = "strSiteVal2",
+                        strSiteCol = "strSiteVal3"
+                        )
+  )
+
+  expect_null(tmp)
+
+})
+
 


### PR DESCRIPTION
## Overview
Fix #393 
- Re-implement `lSubjFilters` in `Study_Assess()`
- Also seems like some `.Rd` files weren't updated when pushed to dev + main

## Test Notes/Sample Code
```r
  lMappingCustom <- clindata::mapping_rawplus
  
  lMappingCustom$dfSUBJ$strSiteVal <- "X010X"
  
  # if dfSUBJ is filtered to 0 rows, warning message thrown and Study_Assess() not run; returns NULL
  # lMappingCustom$dfSUBJ$strRandFlagVal <- "N"
  
  
  tmp <- Study_Assess(lMapping = lMappingCustom, lSubjFilters = list(strSiteCol = "strSiteVal"))
```


