### PR TITLE
display metadata table

### DIFF
--- a/inst/report/studySummary.rmd
+++ b/inst/report/studySummary.rmd
@@ -20,9 +20,21 @@ library(kableExtra)
 library(gt)
 
 if(length(names(params$meta))>1){
-    params$meta %>%
-        kbl(escape=FALSE) %>% 
-        kable_styling()
+  cat("# Metadata Table")
+  params$meta %>%
+    tibble::enframe() %>%
+    tidyr::unnest(cols = value) %>%
+    dplyr::rename(Name = name, Value = value) %>%
+    gt::gt() %>%
+    gt::tab_style(style = list(
+      cell_text(
+        color = 'white',
+        align = "center",
+        weight = "bold"
+      ),
+      cell_fill(color = "#c73442")
+    ),
+    locations = cells_column_labels())
 }
 
 ```


### PR DESCRIPTION
## Overview
The changes in `Study_Report` look good in #484. When I knit the report, it looks like there are some formatting issues with the kable output. 

This is a proposal to include a metadata table when any additional values are added to `lMeta`


## Test Notes/Sample Code
```r
assessment <- Study_Assess()

Study_Report(assessment, lMeta = list(test = 'testing', sometags = "somethingelse"))
```


This creates: 

![image](https://user-images.githubusercontent.com/40671730/169891412-32fccb91-e895-48b6-a169-574816e81f0d.png)
