### PR TITLE
Fix #496 - add labels in data spec header

### DIFF
--- a/R/util-generate_md_table.R
+++ b/R/util-generate_md_table.R
@@ -89,7 +89,19 @@ generate_md_table <- function(
   # Reformat data frame as HTML table.
   knitr.kable.NA <- options(knitr.kable.NA = "")
   on.exit(knitr.kable.NA)
-  md <- knitr::kable(table, format = "markdown") %>%
+  col_name_dict = c(
+    domain = "Domain",
+    col_key = "Column Key",
+    col_value = "Default Value",
+    vRequired = "Required?",
+    vUniqueCols = "Require Unique Values?",
+    vNACols = "Accept NA/Empty Values?"
+  )
+  col_name_dict_bold <- paste0("**", col_name_dict, "**")
+  names(col_name_dict_bold) <- names(col_name_dict) # paste won't keep names
+  md <- knitr::kable(table,
+                     format = "markdown",
+                     col.names = col_name_dict_bold[names(table)]) %>%
     paste(collapse = "\n")
 
   # Append markdown header to HTML table.

--- a/man/AE_Assess.Rd
+++ b/man/AE_Assess.Rd
@@ -65,7 +65,7 @@ methods are described below.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfInput \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfInput \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfInput \tab strCountCol \tab Count \tab TRUE \tab FALSE \cr

--- a/man/AE_Map_Adam.Rd
+++ b/man/AE_Map_Adam.Rd
@@ -45,7 +45,7 @@ AEs by passing filtered AE data to \code{dfADAE}.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfADSL \tab strIDCol \tab USUBJID \tab TRUE \tab TRUE \cr
    dfADSL \tab strSiteCol \tab SITEID \tab TRUE \tab FALSE \cr
    dfADSL \tab strStartCol \tab TRTSDT \tab TRUE \tab FALSE \cr

--- a/man/AE_Map_Raw.Rd
+++ b/man/AE_Map_Raw.Rd
@@ -45,7 +45,7 @@ AEs by passing filtered AE data to \code{dfAE}.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfSUBJ \tab strTimeOnTreatmentCol \tab TimeOnTreatment \tab TRUE \tab FALSE \cr

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -73,7 +73,7 @@ Additional details regarding the data pipeline and statistical methods are descr
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfInput \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfInput \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfInput \tab strCountCol \tab Count \tab TRUE \tab FALSE \cr

--- a/man/Consent_Map_Raw.Rd
+++ b/man/Consent_Map_Raw.Rd
@@ -45,7 +45,7 @@ types of consent by customizing \code{lMapping$dfCONSENT}.
 }
 \section{Data specification}{
 \tabular{llllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vNACols \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Accept NA/Empty Values?} \tab \strong{Require Unique Values?} \cr
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab  \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab  \tab FALSE \cr
    dfSUBJ \tab strRandDateCol \tab RandDate \tab TRUE \tab  \tab FALSE \cr

--- a/man/IE_Assess.Rd
+++ b/man/IE_Assess.Rd
@@ -60,7 +60,7 @@ details regarding the data pipeline and statistical methods are described below.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfInput \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfInput \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfInput \tab strCountCol \tab Count \tab TRUE \tab FALSE \cr

--- a/man/IE_Map_Raw.Rd
+++ b/man/IE_Map_Raw.Rd
@@ -45,7 +45,7 @@ specific types of IE criteria by passing filtered IE data to \code{dfIE}.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfIE \tab strIDCol \tab SubjectID \tab TRUE \tab  \cr

--- a/man/PD_Assess.Rd
+++ b/man/PD_Assess.Rd
@@ -61,7 +61,7 @@ methods are described below.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfInput \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfInput \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfInput \tab strCountCol \tab Count \tab TRUE \tab FALSE \cr

--- a/man/PD_Map_Raw.Rd
+++ b/man/PD_Map_Raw.Rd
@@ -45,7 +45,7 @@ PDs by passing filtered PD data to \code{dfPD}.
 }
 \section{Data specification}{
 \tabular{lllll}{
-   domain \tab col_key \tab col_value \tab vRequired \tab vUniqueCols \cr
+   \strong{Domain} \tab \strong{Column Key} \tab \strong{Default Value} \tab \strong{Required?} \tab \strong{Require Unique Values?} \cr
    dfSUBJ \tab strIDCol \tab SubjectID \tab TRUE \tab TRUE \cr
    dfSUBJ \tab strSiteCol \tab SiteID \tab TRUE \tab FALSE \cr
    dfSUBJ \tab strTimeOnStudyCol \tab TimeOnStudy \tab TRUE \tab FALSE \cr

--- a/man/md/AE_Assess.md
+++ b/man/md/AE_Assess.md
@@ -1,9 +1,9 @@
 # Data specification
 
-|domain  |col_key        |col_value |vRequired |vUniqueCols |
-|:-------|:--------------|:---------|:---------|:-----------|
-|dfInput |strIDCol       |SubjectID |TRUE      |TRUE        |
-|dfInput |strSiteCol     |SiteID    |TRUE      |FALSE       |
-|dfInput |strCountCol    |Count     |TRUE      |FALSE       |
-|dfInput |strExposureCol |Exposure  |TRUE      |FALSE       |
-|dfInput |strRateCol     |Rate      |TRUE      |FALSE       |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfInput    |strIDCol       |SubjectID         |TRUE          |TRUE                       |
+|dfInput    |strSiteCol     |SiteID            |TRUE          |FALSE                      |
+|dfInput    |strCountCol    |Count             |TRUE          |FALSE                      |
+|dfInput    |strExposureCol |Exposure          |TRUE          |FALSE                      |
+|dfInput    |strRateCol     |Rate              |TRUE          |FALSE                      |

--- a/man/md/AE_Map_Adam.md
+++ b/man/md/AE_Map_Adam.md
@@ -1,9 +1,9 @@
 # Data specification
 
-|domain |col_key     |col_value |vRequired |vUniqueCols |
-|:------|:-----------|:---------|:---------|:-----------|
-|dfADSL |strIDCol    |USUBJID   |TRUE      |TRUE        |
-|dfADSL |strSiteCol  |SITEID    |TRUE      |FALSE       |
-|dfADSL |strStartCol |TRTSDT    |TRUE      |FALSE       |
-|dfADSL |strEndCol   |TRTEDT    |TRUE      |FALSE       |
-|dfADAE |strIDCol    |USUBJID   |TRUE      |            |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfADSL     |strIDCol       |USUBJID           |TRUE          |TRUE                       |
+|dfADSL     |strSiteCol     |SITEID            |TRUE          |FALSE                      |
+|dfADSL     |strStartCol    |TRTSDT            |TRUE          |FALSE                      |
+|dfADSL     |strEndCol      |TRTEDT            |TRUE          |FALSE                      |
+|dfADAE     |strIDCol       |USUBJID           |TRUE          |                           |

--- a/man/md/AE_Map_Raw.md
+++ b/man/md/AE_Map_Raw.md
@@ -1,8 +1,8 @@
 # Data specification
 
-|domain |col_key               |col_value       |vRequired |vUniqueCols |
-|:------|:---------------------|:---------------|:---------|:-----------|
-|dfSUBJ |strIDCol              |SubjectID       |TRUE      |TRUE        |
-|dfSUBJ |strSiteCol            |SiteID          |TRUE      |FALSE       |
-|dfSUBJ |strTimeOnTreatmentCol |TimeOnTreatment |TRUE      |FALSE       |
-|dfAE   |strIDCol              |SubjectID       |TRUE      |            |
+|**Domain** |**Column Key**        |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:---------------------|:-----------------|:-------------|:--------------------------|
+|dfSUBJ     |strIDCol              |SubjectID         |TRUE          |TRUE                       |
+|dfSUBJ     |strSiteCol            |SiteID            |TRUE          |FALSE                      |
+|dfSUBJ     |strTimeOnTreatmentCol |TimeOnTreatment   |TRUE          |FALSE                      |
+|dfAE       |strIDCol              |SubjectID         |TRUE          |                           |

--- a/man/md/Consent_Assess.md
+++ b/man/md/Consent_Assess.md
@@ -1,7 +1,7 @@
 # Data specification
 
-|domain  |col_key     |col_value |vRequired |vUniqueCols |
-|:-------|:-----------|:---------|:---------|:-----------|
-|dfInput |strIDCol    |SubjectID |TRUE      |TRUE        |
-|dfInput |strSiteCol  |SiteID    |TRUE      |FALSE       |
-|dfInput |strCountCol |Count     |TRUE      |FALSE       |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfInput    |strIDCol       |SubjectID         |TRUE          |TRUE                       |
+|dfInput    |strSiteCol     |SiteID            |TRUE          |FALSE                      |
+|dfInput    |strCountCol    |Count             |TRUE          |FALSE                      |

--- a/man/md/Consent_Map_Raw.md
+++ b/man/md/Consent_Map_Raw.md
@@ -1,11 +1,11 @@
 # Data specification
 
-|domain    |col_key        |col_value     |vRequired |vNACols |vUniqueCols |
-|:---------|:--------------|:-------------|:---------|:-------|:-----------|
-|dfSUBJ    |strIDCol       |SubjectID     |TRUE      |        |TRUE        |
-|dfSUBJ    |strSiteCol     |SiteID        |TRUE      |        |FALSE       |
-|dfSUBJ    |strRandDateCol |RandDate      |TRUE      |        |FALSE       |
-|dfCONSENT |strIDCol       |SubjectID     |TRUE      |FALSE   |            |
-|dfCONSENT |strTypeCol     |CONSENT_TYPE  |TRUE      |FALSE   |            |
-|dfCONSENT |strValueCol    |CONSENT_VALUE |TRUE      |FALSE   |            |
-|dfCONSENT |strDateCol     |CONSENT_DATE  |TRUE      |TRUE    |            |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:---------------------------|:--------------------------|
+|dfSUBJ     |strIDCol       |SubjectID         |TRUE          |                            |TRUE                       |
+|dfSUBJ     |strSiteCol     |SiteID            |TRUE          |                            |FALSE                      |
+|dfSUBJ     |strRandDateCol |RandDate          |TRUE          |                            |FALSE                      |
+|dfCONSENT  |strIDCol       |SubjectID         |TRUE          |FALSE                       |                           |
+|dfCONSENT  |strTypeCol     |CONSENT_TYPE      |TRUE          |FALSE                       |                           |
+|dfCONSENT  |strValueCol    |CONSENT_VALUE     |TRUE          |FALSE                       |                           |
+|dfCONSENT  |strDateCol     |CONSENT_DATE      |TRUE          |TRUE                        |                           |

--- a/man/md/IE_Assess.md
+++ b/man/md/IE_Assess.md
@@ -1,7 +1,7 @@
 # Data specification
 
-|domain  |col_key     |col_value |vRequired |vUniqueCols |
-|:-------|:-----------|:---------|:---------|:-----------|
-|dfInput |strIDCol    |SubjectID |TRUE      |TRUE        |
-|dfInput |strSiteCol  |SiteID    |TRUE      |FALSE       |
-|dfInput |strCountCol |Count     |TRUE      |FALSE       |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfInput    |strIDCol       |SubjectID         |TRUE          |TRUE                       |
+|dfInput    |strSiteCol     |SiteID            |TRUE          |FALSE                      |
+|dfInput    |strCountCol    |Count             |TRUE          |FALSE                      |

--- a/man/md/IE_Map_Raw.md
+++ b/man/md/IE_Map_Raw.md
@@ -1,9 +1,9 @@
 # Data specification
 
-|domain |col_key        |col_value   |vRequired |vUniqueCols |
-|:------|:--------------|:-----------|:---------|:-----------|
-|dfSUBJ |strIDCol       |SubjectID   |TRUE      |TRUE        |
-|dfSUBJ |strSiteCol     |SiteID      |TRUE      |FALSE       |
-|dfIE   |strIDCol       |SubjectID   |TRUE      |            |
-|dfIE   |strCategoryCol |IE_CATEGORY |TRUE      |            |
-|dfIE   |strValueCol    |IE_VALUE    |TRUE      |            |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfSUBJ     |strIDCol       |SubjectID         |TRUE          |TRUE                       |
+|dfSUBJ     |strSiteCol     |SiteID            |TRUE          |FALSE                      |
+|dfIE       |strIDCol       |SubjectID         |TRUE          |                           |
+|dfIE       |strCategoryCol |IE_CATEGORY       |TRUE          |                           |
+|dfIE       |strValueCol    |IE_VALUE          |TRUE          |                           |

--- a/man/md/PD_Assess.md
+++ b/man/md/PD_Assess.md
@@ -1,9 +1,9 @@
 # Data specification
 
-|domain  |col_key        |col_value |vRequired |vUniqueCols |
-|:-------|:--------------|:---------|:---------|:-----------|
-|dfInput |strIDCol       |SubjectID |TRUE      |TRUE        |
-|dfInput |strSiteCol     |SiteID    |TRUE      |FALSE       |
-|dfInput |strCountCol    |Count     |TRUE      |FALSE       |
-|dfInput |strExposureCol |Exposure  |TRUE      |FALSE       |
-|dfInput |strRateCol     |Rate      |TRUE      |FALSE       |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfInput    |strIDCol       |SubjectID         |TRUE          |TRUE                       |
+|dfInput    |strSiteCol     |SiteID            |TRUE          |FALSE                      |
+|dfInput    |strCountCol    |Count             |TRUE          |FALSE                      |
+|dfInput    |strExposureCol |Exposure          |TRUE          |FALSE                      |
+|dfInput    |strRateCol     |Rate              |TRUE          |FALSE                      |

--- a/man/md/PD_Map_Raw.md
+++ b/man/md/PD_Map_Raw.md
@@ -1,8 +1,8 @@
 # Data specification
 
-|domain |col_key           |col_value   |vRequired |vUniqueCols |
-|:------|:-----------------|:-----------|:---------|:-----------|
-|dfSUBJ |strIDCol          |SubjectID   |TRUE      |TRUE        |
-|dfSUBJ |strSiteCol        |SiteID      |TRUE      |FALSE       |
-|dfSUBJ |strTimeOnStudyCol |TimeOnStudy |TRUE      |FALSE       |
-|dfPD   |strIDCol          |SubjectID   |TRUE      |            |
+|**Domain** |**Column Key**    |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:-----------------|:-----------------|:-------------|:--------------------------|
+|dfSUBJ     |strIDCol          |SubjectID         |TRUE          |TRUE                       |
+|dfSUBJ     |strSiteCol        |SiteID            |TRUE          |FALSE                      |
+|dfSUBJ     |strTimeOnStudyCol |TimeOnStudy       |TRUE          |FALSE                      |
+|dfPD       |strIDCol          |SubjectID         |TRUE          |                           |


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Fix #496 
- Created a new variable `col_name_dict` in `R/util-generate_md_table.R` which maps raw data spec column names such as `col_key` to readable name `Column Key`. 
- The derived `col_name_dict_bold` is used when generating markdown tables. 
- The docs affected by this fix are updated consequently. 

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->
```r
  col_name_dict = c(
    domain = "Domain",
    col_key = "Column Key",
    col_value = "Default Value",
    vRequired = "Required?",
    vUniqueCols = "Require Unique Values?",
    vNACols = "Accept NA/Empty Values?"
  )
  col_name_dict_bold <- paste0("**", col_name_dict, "**")
  names(col_name_dict_bold) <- names(col_name_dict) # paste won't keep names
  md <- knitr::kable(table,
                     format = "markdown",
                     col.names = col_name_dict_bold[names(table)])
```

Traceback: 
`R/util-generate_md_table.R` <--
`R/build-md.R` <--
`.github/workflows/build_markdown.yaml`: `build_markdown("inst/mappings/mapping_adam.yaml")`

