### PR TITLE
fix #435

### DIFF
--- a/R/Study_Assess.R
+++ b/R/Study_Assess.R
@@ -28,6 +28,18 @@ Study_Assess <- function(
   lTags = list(Study = "myStudy"),
   bQuiet = FALSE
 ) {
+  if (!is.null(lTags)) {
+    stopifnot(
+      "lTags is not named" = (!is.null(names(lTags))),
+      "lTags has unnamed elements" = all(names(lTags) != ""),
+      "lTags cannot contain elements named: 'Assessment', 'Label'" = !names(lTags) %in% c("Assessment", "Label")
+    )
+
+    if (any(unname(purrr::map_dbl(lTags, ~ length(.))) > 1)) {
+      lTags <- purrr::map(lTags, ~ paste(.x, collapse = ", "))
+    }
+  }
+
   #### --- load defaults --- ###
   # lData from clindata
   if (is.null(lData)) {

--- a/tests/testthat/_snaps/Study_Assess.md
+++ b/tests/testthat/_snaps/Study_Assess.md
@@ -378,3 +378,23 @@
       v `AE_Assess()` Successful
       Saving lResults to `lAssessment`
 
+# incorrect lTags throw errors
+
+    lTags is not named
+
+---
+
+    lTags is not named
+
+---
+
+    lTags has unnamed elements
+
+---
+
+    lTags cannot contain elements named: 'Assessment', 'Label'
+
+---
+
+    lTags cannot contain elements named: 'Assessment', 'Label'
+

--- a/tests/testthat/test_Study_Assess.R
+++ b/tests/testthat/test_Study_Assess.R
@@ -125,8 +125,7 @@ test_that("lTags are carried through", {
     lTags = list(
       Study = "test study",
       Q = "Q2 2022",
-      Region = "Northwest",
-      Assessment = "none"
+      Region = "Northwest"
     )
   )
 
@@ -134,7 +133,7 @@ test_that("lTags are carried through", {
     result$ae$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "Safety", Label = "AEs"
+      Assessment = "Safety", Label = "AEs"
     )
   )
 
@@ -142,7 +141,7 @@ test_that("lTags are carried through", {
     result$consent$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "Consent", Label = "Consent"
+      Assessment = "Consent", Label = "Consent"
     )
   )
 
@@ -150,7 +149,7 @@ test_that("lTags are carried through", {
     result$ie$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "IE", Label = "IE"
+      Assessment = "IE", Label = "IE"
     )
   )
 
@@ -158,7 +157,7 @@ test_that("lTags are carried through", {
     result$importantpd$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "PD", Label = "Important PD"
+      Assessment = "PD", Label = "Important PD"
     )
   )
 
@@ -166,7 +165,7 @@ test_that("lTags are carried through", {
     result$pd$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "PD", Label = "PD"
+      Assessment = "PD", Label = "PD"
     )
   )
 
@@ -174,19 +173,17 @@ test_that("lTags are carried through", {
     result$sae$lResults$lTags,
     list(
       Study = "test study", Q = "Q2 2022", Region = "Northwest",
-      Assessment = "none", Assessment = "Safety", Label = "AEs Serious"
+      Assessment = "Safety", Label = "AEs Serious"
     )
   )
+})
 
-
-
-  # Issue #435: duplicate lTags
-  # result <- Study_Assess(lData = lData,
-  #                        lTags = list(Study = "test study",
-  #                                     Q = "Q2 2022",
-  #                                     Region = "Northwest",
-  #                                     Assessment = "none",
-  #                                     Label = "my label"))
+test_that("incorrect lTags throw errors", {
+  expect_snapshot_error(Study_Assess(lTags = "hi mom"))
+  expect_snapshot_error(Study_Assess(lTags = list("hi", "mom")))
+  expect_snapshot_error(Study_Assess(lTags = list(greeting = "hi", "mom")))
+  expect_snapshot_error(Study_Assess(lTags = list(Assessment = "this is not an assessment")))
+  expect_snapshot_error(Study_Assess(lTags = list(Label = "this is not a label")))
 })
 
 test_that("Map + Assess yields same result as Study_Assess()", {


### PR DESCRIPTION
## Overview
Prevent `lTags` of _Assessment_ and _Label_ in `Study_Assess()`.

## Test Notes/Sample Code
```
Study_Assess(lTags = list(Assessment = 'this is not an assessment'))
Study_Assess(lTags = list(Label = 'this is not a  label'))
Study_Assess(lTags = list(Assessment = 'asdf', Label = 'asdf'))
```

Notes: 
I wonder if there's a better place to store assessment tags than as a column in the summary dataset.