### PR TITLE
Add explicit aesthetic that maps to tooltip in {plotly}.

### DIFF
--- a/R/Visualize_Count.R
+++ b/R/Visualize_Count.R
@@ -30,12 +30,23 @@ Visualize_Count <- function(dfAnalyzed, strTotalCol = "N", strCountCol = "TotalC
     "strTitle must be character" = is.character(strTitle)
   )
 
-  p <- ggplot(
-    data = dfAnalyzed,
-    aes(x = reorder(.data$SiteID, -.data$N))
-  ) +
+  # Define tooltip for use in plotly.
+  dfAnalyzedWithTooltip <- dfAnalyzed %>%
+    mutate(
+      tooltip = paste(
+        paste0('Site: ', .data$SiteID),
+        paste0('# of Events: ', format(.data$N, big.mark = ',', trim = TRUE)),
+        sep = '\n'
+      )
+    )
+
+  p <- dfAnalyzedWithTooltip %>%
+    ggplot(
+      aes(x = reorder(.data$SiteID, -.data$N), text = .data$tooltip)
+    ) +
     geom_bar(aes(y = .data[[strTotalCol]]), stat = "identity", color = "black", fill = "white") +
     geom_bar(aes(y = .data[[strCountCol]]), stat = "identity", fill = "red") +
+    scale_x_discrete(guide = guide_axis(check.overlap = TRUE)) +
     ggtitle(strTitle) +
     labs(
       x = "Site ID",

--- a/R/Visualize_Scatter.R
+++ b/R/Visualize_Scatter.R
@@ -20,16 +20,27 @@
 #' @export
 
 Visualize_Scatter <- function(dfFlagged, dfBounds = NULL, strUnit = "days") {
+  # Define tooltip for use in plotly.
+  dfFlaggedWithTooltip <- dfFlagged %>%
+    mutate(
+      tooltip = paste(
+        paste0('Site: ', .data$SiteID),
+        paste0('Exposure (days): ', format(.data$TotalExposure, big.mark = ',', trim = TRUE)),
+        paste0('# of Events: ', format(.data$TotalCount, big.mark = ',', trim = TRUE)),
+        sep = '\n'
+      )
+    )
 
   ### Plot of data
-  p <- ggplot(
-    dfFlagged,
-    aes(
-      x = log(.data$TotalExposure),
-      y = .data$TotalCount,
-      color = as.factor(.data$Flag)
-    )
-  ) +
+  p <- dfFlaggedWithTooltip %>%
+    ggplot(
+      aes(
+        x = log(.data$TotalExposure),
+        y = .data$TotalCount,
+        color = as.factor(.data$Flag),
+        text = .data$tooltip
+      )
+    ) +
     # Formatting
     theme_bw() +
     scale_x_continuous(
@@ -46,7 +57,7 @@ Visualize_Scatter <- function(dfFlagged, dfBounds = NULL, strUnit = "days") {
     xlab(paste0("Site Total Exposure (", strUnit, " - log scale)")) +
     ylab("Site Total Events") +
     geom_text(
-      data = dfFlagged %>% filter(.data$Flag != 0),
+      data = dfFlaggedWithTooltip %>% filter(.data$Flag != 0),
       aes(x = log(.data$TotalExposure), y = .data$TotalCount, label = .data$SiteID),
       vjust = 1.5,
       col = "red",
@@ -55,9 +66,9 @@ Visualize_Scatter <- function(dfFlagged, dfBounds = NULL, strUnit = "days") {
 
   if (!is.null(dfBounds)) {
     p <- p +
-      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$MeanCount), color = "red") +
-      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$LowerCount), color = "red", linetype = "dashed") +
-      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$UpperCount), color = "red", linetype = "dashed")
+      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$MeanCount), color = "red", inherit.aes = FALSE) +
+      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$LowerCount), color = "red", linetype = "dashed", inherit.aes = FALSE) +
+      geom_line(data = dfBounds, aes(x = .data$LogExposure, y = .data$UpperCount), color = "red", linetype = "dashed", inherit.aes = FALSE)
   }
 
   return(p)

--- a/tests/testthat/test_Visualize_Count.R
+++ b/tests/testthat/test_Visualize_Count.R
@@ -26,3 +26,8 @@ test_that("incorrect inputs throw errors", {
   expect_error(Visualize_Count(consent_assess$dfAnalyzed, strFlagCol = 1))
   expect_error(Visualize_Count(consent_assess$dfAnalyzed, strTitle = list()))
 })
+
+test_that("Chart has [ text ] aesthetic", {
+  ie_assess <- IE_Assess(ieInput)
+  expect_true('text' %in% names(ie_assess$chart$mapping))
+})

--- a/tests/testthat/test_Visualize_Scatter.R
+++ b/tests/testthat/test_Visualize_Scatter.R
@@ -1,7 +1,6 @@
 source(testthat::test_path("testdata/data.R"))
 
 test_that("Output is produced", {
-
   # poisson model
   dfInput <- AE_Map_Adam(dfs = list(dfADSL = dfADSL, dfADAE = dfADAE))
   SafetyAE <- AE_Assess(dfInput, strMethod = "poisson")
@@ -14,4 +13,12 @@ test_that("Output is produced", {
   SafetyAE <- AE_Assess(dfInput, strMethod = "wilcoxon")
   Visualize_Scatter(SafetyAE$dfFlagged)
   expect_silent(Visualize_Scatter(SafetyAE$dfFlagged))
+})
+
+test_that("Chart has [ text ] aesthetic", {
+  dfInput <- AE_Map_Adam(dfs = list(dfADSL = dfADSL, dfADAE = dfADAE))
+  assessment <- AE_Assess(dfInput)
+  dfBounds <- Analyze_Poisson_PredictBounds(assessment$dfTransformed, c(-5, 5))
+  chart <- Visualize_Scatter(assessment$dfFlagged, dfBounds)
+  expect_true('text' %in% names(chart$mapping))
 })


### PR DESCRIPTION
## Overview
Adds a human-readable tooltip for use downstream in `{plotly}`.

## Test Notes/Sample Code
```
ae_assessment <- AE_Assess(AE_Map_Raw())
ggplotly(ae_assessment$chart, tooltip = 'text')

ie_assessment <- IE_Assess(IE_Map_Raw())
ggplotly(ie_assessment$chart, tooltip = 'text')
```

Notes: 
Adding the `text` aesthetic to the `{ggplot}` object after creation wasn't trivial and might even be impossible.