### PR TITLE
Fix #646 + #677: update documentation + remove dfBounds from flowchart

### DIFF
--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -1,5 +1,7 @@
 #' Consent Assessment
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Evaluates sites where subject consent was:
 #' - not given

--- a/R/Consent_Map_Raw.R
+++ b/R/Consent_Map_Raw.R
@@ -1,5 +1,7 @@
 #' Consent Assessment - Raw Mapping
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Convert raw informed consent data, typically processed case report from data, to formatted
 #' input data to [gsm::Consent_Assess()].

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -1,5 +1,7 @@
 #' Inclusion/Exclusion Assessment
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Evaluates sites exhibiting aberrant or excessive rates of unmet or missing inclusion/exclusion (IE) criteria.
 #'

--- a/R/IE_Map_Raw.R
+++ b/R/IE_Map_Raw.R
@@ -1,5 +1,7 @@
 #' Inclusion/Exclusion Assessment - Raw Mapping
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Convert raw inclusion/exclusion (IE) data, typically processed case report form data, to formatted
 #' input data to [gsm::IE_Assess()].

--- a/R/LB_Assess.R
+++ b/R/LB_Assess.R
@@ -1,5 +1,7 @@
 #' Labs Assessment
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Evaluates rate of reported Lab Abnormalities (LB).
 #'

--- a/R/LB_Map_Raw.R
+++ b/R/LB_Map_Raw.R
@@ -1,5 +1,7 @@
 #' Lab Assessment - Raw Mapping
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @description
 #' Convert from ADaM or raw format to input format for Labs Assessment.
 #'

--- a/R/Visualize_Workflow.R
+++ b/R/Visualize_Workflow.R
@@ -5,13 +5,10 @@
 #' @return A flowchart of type `grViz`/`htmlwidget`.
 #'
 #' @examples
-#' lAssessments <- MakeAssessmentList()
+#' lAssessments <- list(ae = MakeAssessmentList()$ae)
 #' lData <- list(
 #'   dfSUBJ = clindata::rawplus_subj,
-#'   dfAE = clindata::rawplus_ae,
-#'   dfPD = clindata::rawplus_pd,
-#'   dfCONSENT = clindata::rawplus_consent,
-#'   dfIE = clindata::rawplus_ie
+#'   dfAE = clindata::rawplus_ae
 #' )
 #' lTags <- list(
 #'   Study = "myStudy"
@@ -82,7 +79,10 @@ Visualize_Workflow <- function(lAssessments) {
         ungroup()
 
 
-      pipeline <- studyObject$lResults[grep("df", names(studyObject$lResults))] %>%
+      pipelineSubset <- studyObject$lResults[grep("df", names(studyObject$lResults))]
+      pipelineSubset[["dfBounds"]] <- NULL
+
+      pipeline <- pipelineSubset %>%
         purrr::imap_dfr(
           ~ tibble(
             assessment = name,

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -65,6 +65,8 @@ Evaluates sites where subject consent was:
 }
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 The Consent Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag sites with consent issues. This assessment detects sites with subjects who participated
 in study activities before consent was finalized. The count returned in the summary represents
 the number of subjects at a given site for whom:

--- a/man/Consent_Map_Raw.Rd
+++ b/man/Consent_Map_Raw.Rd
@@ -39,6 +39,8 @@ Convert raw informed consent data, typically processed case report from data, to
 input data to \code{\link[=Consent_Assess]{Consent_Assess()}}.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 \code{Consent_Map_Raw} combines consent data with subject-level data to create formatted input data
 to \code{\link[=Consent_Assess]{Consent_Assess()}}. This function creates an input dataset for the Consent Assessment
 (${Consent_Assess()} by binding subject-level counts of consent issues (derived from \code{dfCONSENT}) to

--- a/man/IE_Assess.Rd
+++ b/man/IE_Assess.Rd
@@ -59,6 +59,8 @@ IE_Assess(
 Evaluates sites exhibiting aberrant or excessive rates of unmet or missing inclusion/exclusion (IE) criteria.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 The IE Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag sites with IE issues. This assessment detects sites with excessive rates of unmet or
 missing IE criteria, as defined by \code{nThreshold}. The count returned in the summary represents the
 number of subjects at a given site with at least one unmet or missing IE criterion.

--- a/man/IE_Map_Raw.Rd
+++ b/man/IE_Map_Raw.Rd
@@ -39,6 +39,8 @@ Convert raw inclusion/exclusion (IE) data, typically processed case report form 
 input data to \code{\link[=IE_Assess]{IE_Assess()}}.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 \code{IE_Map_Raw} combines IE data with subject-level data to create formatted input data to
 \code{\link[=IE_Assess]{IE_Assess()}}. This function creates an input dataset for the IE Assessment
 (\code{\link[=IE_Assess]{IE_Assess()}}) by binding subject-level unmet IE criteria counts (derived from \code{dfIE}) to

--- a/man/LB_Assess.Rd
+++ b/man/LB_Assess.Rd
@@ -70,6 +70,8 @@ and each tag is added as a column in \code{lAssess$dfSummary}.}
 Evaluates rate of reported Lab Abnormalities (LB).
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 The Lab Abnormality Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/LB_Map_Raw.Rd
+++ b/man/LB_Map_Raw.Rd
@@ -38,6 +38,8 @@ of the column.}
 Convert from ADaM or raw format to input format for Labs Assessment.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 Convert raw lab data (LB), typically processed case report form data, to formatted
 input data to \code{\link[=LB_Assess]{LB_Assess()}}.
 

--- a/man/Visualize_Workflow.Rd
+++ b/man/Visualize_Workflow.Rd
@@ -16,13 +16,10 @@ A flowchart of type \code{grViz}/\code{htmlwidget}.
 Flowchart visualization of data pipeline steps from filtering to summary data for an assessment workflow.
 }
 \examples{
-lAssessments <- MakeAssessmentList()
+lAssessments <- list(ae = MakeAssessmentList()$ae)
 lData <- list(
   dfSUBJ = clindata::rawplus_subj,
-  dfAE = clindata::rawplus_ae,
-  dfPD = clindata::rawplus_pd,
-  dfCONSENT = clindata::rawplus_consent,
-  dfIE = clindata::rawplus_ie
+  dfAE = clindata::rawplus_ae
 )
 lTags <- list(
   Study = "myStudy"


### PR DESCRIPTION
## Overview
Fix #677 - add `lifecycle::badge("experimental")` to non-qualified assessment functions (map + assess)
Fix #646 - remove `dfBounds` from `Visualize_Workflow()` by setting to `NULL` 



