### PR TITLE
Fix #655 - Functionalize lAssess

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -35,7 +35,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -100,7 +99,6 @@ AE_Assess <- function(dfInput,
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -41,7 +41,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -103,7 +102,6 @@ Consent_Assess <- function(dfInput,
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/Disp_Assess.R
+++ b/R/Disp_Assess.R
@@ -34,7 +34,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -103,7 +102,6 @@ Disp_Assess <- function(
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -30,7 +30,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -93,7 +92,6 @@ IE_Assess <- function(dfInput,
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/LB_Assess.R
+++ b/R/LB_Assess.R
@@ -36,7 +36,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -105,7 +104,6 @@ LB_Assess <- function(
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/R/PD_Assess.R
+++ b/R/PD_Assess.R
@@ -35,7 +35,6 @@
 #'   - `dfSummary`, returned by [gsm::Summarize()]
 #' - assessment metadata
 #'   - `strFunctionName`
-#'   - `lParams`
 #'   - `lTags`
 #' - output(s)
 #'   - `chart`
@@ -100,7 +99,6 @@ PD_Assess <- function(dfInput,
 
   lAssess <- list(
     strFunctionName = deparse(sys.call()[1]),
-    lParams = lapply(imap(formals()[! names(formals()) %in% c("dfInput", "lTags")], function(x, y){eval(sym(y))}), as.character),
     lTags = lTags,
     dfInput = dfInput
   )

--- a/tests/testthat/_snaps/AE_Assess.md
+++ b/tests/testthat/_snaps/AE_Assess.md
@@ -134,29 +134,6 @@
       $strFunctionName
       [1] "assess_function()"
       
-      $lParams
-      $lParams$vThreshold
-      character(0)
-      
-      $lParams$strMethod
-      [1] "poisson"
-      
-      $lParams$strKRILabel
-      [1] "AEs/Week"
-      
-      $lParams$strGroup
-      [1] "Site"
-      
-      $lParams$bChart
-      [1] "TRUE"
-      
-      $lParams$bReturnChecks
-      [1] "FALSE"
-      
-      $lParams$bQuiet
-      [1] "TRUE"
-      
-      
       $lTags
       $lTags$Assessment
       [1] "AE"

--- a/tests/testthat/_snaps/PD_Assess.md
+++ b/tests/testthat/_snaps/PD_Assess.md
@@ -122,29 +122,6 @@
       $strFunctionName
       [1] "assess_function()"
       
-      $lParams
-      $lParams$vThreshold
-      character(0)
-      
-      $lParams$strMethod
-      [1] "poisson"
-      
-      $lParams$strKRILabel
-      [1] "PDs/Week"
-      
-      $lParams$strGroup
-      [1] "Site"
-      
-      $lParams$bChart
-      [1] "TRUE"
-      
-      $lParams$bReturnChecks
-      [1] "FALSE"
-      
-      $lParams$bQuiet
-      [1] "TRUE"
-      
-      
       $lTags
       $lTags$Assessment
       [1] "PD"

--- a/tests/testthat/test_AE_Assess.R
+++ b/tests/testthat/test_AE_Assess.R
@@ -11,7 +11,6 @@ test_that("output is created as expected", {
   expect_true(is.list(assessment))
   expect_equal(names(assessment), c(
     "strFunctionName",
-    "lParams",
     "lTags",
     "dfInput",
     "dfTransformed",
@@ -28,23 +27,15 @@ test_that("output is created as expected", {
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_true("data.frame" %in% class(assessment$dfBounds))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
 # metadata is returned as expected ----------------------------------------
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput, vThreshold = c(-5.1, 5.1))
-
-  allArgs <- names(formals("AE_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
-  expect_equal("-5.1", assessment$lParams$vThreshold[1])
-  expect_equal("5.1", assessment$lParams$vThreshold[2])
   expect_equal("AE", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
 })
 
 

--- a/tests/testthat/test_Consent_Assess.R
+++ b/tests/testthat/test_Consent_Assess.R
@@ -9,14 +9,13 @@ output_mapping <- yaml::read_yaml(system.file("mappings", "Consent_Assess.yaml",
 test_that("output is created as expected", {
   assessment <- assess_function(dfInput)
   expect_true(is.list(assessment))
-  expect_equal(names(assessment), c("strFunctionName", "lParams", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
+  expect_equal(names(assessment), c("strFunctionName", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
   expect_true("data.frame" %in% class(assessment$dfInput))
   expect_true("data.frame" %in% class(assessment$dfTransformed))
   expect_true("data.frame" %in% class(assessment$dfAnalyzed))
   expect_true("data.frame" %in% class(assessment$dfFlagged))
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
@@ -24,14 +23,9 @@ test_that("output is created as expected", {
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput, nThreshold = 0.6)
 
-  allArgs <- names(formals("Consent_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
-  expect_equal("0.6", assessment$lParams$nThreshold)
   expect_equal("Consent", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
 })
 
 # grouping works as expected ----------------------------------------------

--- a/tests/testthat/test_Disp_Assess.R
+++ b/tests/testthat/test_Disp_Assess.R
@@ -9,28 +9,22 @@ output_mapping <- yaml::read_yaml(system.file("mappings", "Disp_Assess.yaml", pa
 test_that("output is created as expected", {
   assessment <- assess_function(dfInput)
   expect_true(is.list(assessment))
-  expect_equal(names(assessment), c("strFunctionName", "lParams", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
+  expect_equal(names(assessment), c("strFunctionName", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
   expect_true("data.frame" %in% class(assessment$dfInput))
   expect_true("data.frame" %in% class(assessment$dfTransformed))
   expect_true("data.frame" %in% class(assessment$dfAnalyzed))
   expect_true("data.frame" %in% class(assessment$dfFlagged))
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
 # metadata is returned as expected ----------------------------------------
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput)
-
-  allArgs <- names(formals("Disp_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
   expect_equal("Disposition", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
 })
 
 # grouping works as expected ----------------------------------------------

--- a/tests/testthat/test_IE_Assess.R
+++ b/tests/testthat/test_IE_Assess.R
@@ -9,29 +9,22 @@ output_mapping <- yaml::read_yaml(system.file("mappings", "IE_Assess.yaml", pack
 test_that("output is created as expected", {
   assessment <- assess_function(dfInput)
   expect_true(is.list(assessment))
-  expect_equal(names(assessment), c("strFunctionName", "lParams", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
+  expect_equal(names(assessment), c("strFunctionName", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
   expect_true("data.frame" %in% class(assessment$dfInput))
   expect_true("data.frame" %in% class(assessment$dfTransformed))
   expect_true("data.frame" %in% class(assessment$dfAnalyzed))
   expect_true("data.frame" %in% class(assessment$dfFlagged))
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
 # metadata is returned as expected ----------------------------------------
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput, nThreshold = 0.755555)
-
-  allArgs <- names(formals("IE_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
-  expect_equal("0.755555", assessment$lParams$nThreshold)
   expect_equal("IE", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
 })
 
 # grouping works as expected ----------------------------------------------

--- a/tests/testthat/test_LB_Assess.R
+++ b/tests/testthat/test_LB_Assess.R
@@ -9,28 +9,22 @@ output_mapping <- yaml::read_yaml(system.file("mappings", "LB_Assess.yaml", pack
 test_that("output is created as expected", {
   assessment <- assess_function(dfInput)
   expect_true(is.list(assessment))
-  expect_equal(names(assessment), c("strFunctionName", "lParams", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
+  expect_equal(names(assessment), c("strFunctionName", "lTags", "dfInput", "dfTransformed", "dfAnalyzed", "dfFlagged", "dfSummary", "chart"))
   expect_true("data.frame" %in% class(assessment$dfInput))
   expect_true("data.frame" %in% class(assessment$dfTransformed))
   expect_true("data.frame" %in% class(assessment$dfAnalyzed))
   expect_true("data.frame" %in% class(assessment$dfFlagged))
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
 # metadata is returned as expected ----------------------------------------
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput)
-
-  allArgs <- names(formals("PD_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
   expect_equal("Labs", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
 })
 
 # incorrect inputs throw errors -------------------------------------------

--- a/tests/testthat/test_PD_Assess.R
+++ b/tests/testthat/test_PD_Assess.R
@@ -11,7 +11,6 @@ test_that("output is created as expected", {
   expect_true(is.list(assessment))
   expect_equal(names(assessment), c(
     "strFunctionName",
-    "lParams",
     "lTags",
     "dfInput",
     "dfTransformed",
@@ -28,23 +27,16 @@ test_that("output is created as expected", {
   expect_true("data.frame" %in% class(assessment$dfSummary))
   expect_true("data.frame" %in% class(assessment$dfBounds))
   expect_type(assessment$strFunctionName, "character")
-  expect_type(assessment$lParams, "list")
   expect_type(assessment$lTags, "list")
 })
 
 # metadata is returned as expected ----------------------------------------
 test_that("metadata is returned as expected", {
   assessment <- assess_function(dfInput, vThreshold = c(-5.1, 5.1), strMethod = "poisson")
-
-  allArgs <- names(formals("PD_Assess"))
-  expectedArgs <- allArgs[!allArgs %in% c("dfInput", "lTags")]
-
   expect_equal("assess_function()", assessment$strFunctionName)
-  expect_equal("-5.1", assessment$lParams$vThreshold[1])
-  expect_equal("5.1", assessment$lParams$vThreshold[2])
   expect_equal("PD", assessment$lTags$Assessment)
   expect_true("ggplot" %in% class(assessment$chart))
-  expect_true(all(expectedArgs %in% names(assessment$lParams)))
+  
 })
 
 # grouping works as expected ----------------------------------------------

--- a/tests/testthat/test_util-runAssessment.R
+++ b/tests/testthat/test_util-runAssessment.R
@@ -71,21 +71,3 @@ test_that("workflow with multiple FilterDomain steps is reported correctly", {
 
   expect_equal(names(sae_assessment$checks), c("FilterDomain", "FilterDomain", "AE_Map_Raw", "AE_Assess"))
 })
-
-test_that("lParams is equivalent to Map + Assess", {
-
-  dfInputAE <- AE_Map_Raw(
-    dfs = list(
-      dfAE = dfAE,
-      dfSUBJ = dfSUBJ
-      )
-    )
-
-  aeAssessment <- AE_Assess(
-    dfInputAE,
-    strKRILabel = "Serious Treatment-Emergent AEs/Week",
-    bReturnChecks = T
-    )
-
-  expect_equal(aeAssessment$lParams, sae$lResults$lParams)
-})

--- a/tests/testthat/test_util_ConsolidateStrata.R
+++ b/tests/testthat/test_util_ConsolidateStrata.R
@@ -31,7 +31,7 @@ test_that("Structure of consolidated output matches structure of standard output
 test_that("Stratified output is returned", {
   expect_true(is.list(lConsolidatedOutput))
   expect_equal(
-    c("chart", "dfAnalyzed", "dfBounds", "dfFlagged", "dfInput", "dfSummary", "dfTransformed", "lChecks", "lParams", "lTags", "strFunctionName"),
+    c("chart", "dfAnalyzed", "dfBounds", "dfFlagged", "dfInput", "dfSummary", "dfTransformed", "lChecks", "lTags", "strFunctionName"),
     names(lConsolidatedOutput$lResults) %>% sort()
   )
   expect_equal(

--- a/tests/testthat/test_util_RunStratifiedWorkflow.R
+++ b/tests/testthat/test_util_RunStratifiedWorkflow.R
@@ -35,7 +35,7 @@ test_that("Structure of stratified output matches structure of standard output",
 test_that("Stratified output is returned", {
   expect_true(is.list(stratifiedOutput))
   expect_equal(
-    c("chart", "dfAnalyzed", "dfBounds", "dfFlagged", "dfInput", "dfSummary", "dfTransformed", "lChecks", "lParams", "lTags", "strFunctionName"),
+    c("chart", "dfAnalyzed", "dfBounds", "dfFlagged", "dfInput", "dfSummary", "dfTransformed", "lChecks", "lTags", "strFunctionName"),
     names(stratifiedOutput$lResults) %>% sort()
   )
   expect_equal(


### PR DESCRIPTION
## Overview
Fix #655

Props to @kodesiba for working through this one. 

In short, using `match.call()` was pulling incorrect params because it's looking to the parent environment, which changes when we run `*_Assess()` functions in wrapper functions (and would likely get more confusing if we add another layer of wrapper function on top of `Study_Assess()`/`RunAssessment()`. 

Also prevents our data.frames from being coerced into huge character vectors, which will hopefully cut back on processing time (at least a little bit)

