### PR TITLE
Update overall discontinuation rate; remove bug in `Study_AssessmentReport`.

### DIFF
--- a/R/Study_AssessmentReport.R
+++ b/R/Study_AssessmentReport.R
@@ -38,7 +38,7 @@ Study_AssessmentReport <- function(lAssessments, bViewReport = FALSE) {
       )
 
     allChecks <- map(lAssessments[[assessment]][["checks"]], function(step) {
-      domains <- names(step[!names(step) %in% c("status", "mapping")])
+      domains <- names(step[!names(step) %in% c('mapping', 'spec', "status")])
 
       map(domains, function(domain) {
         status <- step[[domain]][["status"]]

--- a/R/Visualize_Score.R
+++ b/R/Visualize_Score.R
@@ -68,7 +68,7 @@ Visualize_Score <- function(
           if ("TotalExposure" %in% names(dfFlagged)) {
             sum(dfFlagged$TotalCount) / sum(dfFlagged$TotalExposure)
           } else {
-            sum(dfFlagged$TotalCount) / nrow(dfFlagged)
+            sum(dfFlagged$TotalCount) / sum(dfFlagged$N)
           }
         ),
         linetype = "dashed",


### PR DESCRIPTION
## Overview
- Update overall discontinuation rate from `# discontinued / # of sites` to `# discontinued / # of participants`.
- In `Study_AssessmentReport` where the checks of each domain are compiled, the `checks` object is a named list with associated data domains, `'status'`, `'mapping'`, and `'spec'`, but `'spec'` isn't removed from the list of names.