### PR TITLE
pass thresholds to rbm-viz as a simple vector/array

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -199,20 +199,20 @@ AE_Assess <- function(
     }
 
     # yaxis = "metric"
-    dfThreshold <- tibble(default = vThreshold) %>%
-      mutate(index = row_number(),
-             workflowid = "kri0001",
-             param = "vThreshold",
-             configurable = "TRUE",
-             gsm_version = "v1.1.0") %>%
-      arrange(.data$default)
+    #dfThreshold <- tibble(default = vThreshold) %>%
+    #  mutate(index = row_number(),
+    #         workflowid = "kri0001",
+    #         param = "vThreshold",
+    #         configurable = "TRUE",
+    #         gsm_version = "v1.1.0") %>%
+    #  arrange(.data$default)
 
 
 
 
     dfConfig <- tibble::tribble(
-      ~group,              ~score,               ~numerator,        ~denominator,
-      "Site", "Adjusted Z-Score ", "Treatment Emergent AEs", "Days on Treatment"
+      ~group,              ~score,               ~numerator,        ~denominator, ~thresholds,
+      "Site", "Adjusted Z-Score ", "Treatment Emergent AEs", "Days on Treatment", vThreshold
     )
 
     lCharts$barMetric <- gsm::Visualize_Score(dfFlagged = lData$dfFlagged, strType = "metric")
@@ -228,7 +228,7 @@ AE_Assess <- function(
     lCharts$barScoreJS <- barChart(
       data = lData$dfFlagged %>% rename_all(~tolower(.)),
       config = dfConfig,
-      threshold = dfThreshold,
+      #threshold = dfThreshold,
       yaxis = "score",
       elementId = "AE_Assess()"
     )

--- a/R/barChart.R
+++ b/R/barChart.R
@@ -59,7 +59,7 @@ barChart <- function(
       elementId = NULL) {
 
   data <- dplyr::mutate(data, across(everything(), as.character))
-  config <- dplyr::mutate(config, across(everything(), as.character))
+  # config <- dplyr::mutate(config, across(everything(), as.character))
   # threshold <- dplyr::mutate(threshold, across(everything(), as.character))
 
   # forward options using x

--- a/inst/htmlwidgets/barChart.js
+++ b/inst/htmlwidgets/barChart.js
@@ -15,6 +15,7 @@ HTMLWidgets.widget({
       let config = HTMLWidgets.dataframeToD3(x.config)[0]
       config.y = x.yaxis
       config.selectedGroupIDs = number_to_array(x.selectedGroupIDs)
+          console.log(config);
 
       let threshold = HTMLWidgets.dataframeToD3(x.threshold)
 


### PR DESCRIPTION
Simpler way to pass thresholds without `meta_param`.  The annoying thing is we're still kind of hard-coding `meta_workflow`.  I wonder if `rbm-viz` should be able to run without all the metadata...
