### PR TITLE
Fix 1006 - make flowchart optional

### DIFF
--- a/R/Make_Snapshot.R
+++ b/R/Make_Snapshot.R
@@ -15,6 +15,7 @@
 #' @param bUpdateParams `logical` if `TRUE`, configurable parameters found in `lMeta$config_param` will overwrite the default values in `lMeta$meta_params`. Default: `FALSE`.
 #' @param cPath `character` a character string indicating a working directory to save .csv files; the output of the snapshot.
 #' @param bQuiet `logical` Suppress warning messages? Default: `TRUE`
+#' @param bFlowchart `logical` Create flowchart to show data pipeline? Default: `FALSE`
 #'
 #' @includeRmd ./man/md/Make_Snapshot.md
 #'
@@ -68,7 +69,8 @@ lMapping = c(
 lAssessments = NULL,
 bUpdateParams = FALSE,
 cPath = NULL,
-bQuiet = TRUE
+bQuiet = TRUE,
+bFlowchart = FALSE
 
 ) {
 

--- a/R/Study_Assess.R
+++ b/R/Study_Assess.R
@@ -8,6 +8,7 @@
 #' @param lAssessments `list` a named list of metadata defining how each assessment should be run. By default, `MakeWorkflowList()` imports YAML specifications from `inst/workflow`.
 #' @param lSubjFilters `list` a named list of parameters to filter subject-level data on.
 #' @param bQuiet `logical` Suppress warning messages? Default: `TRUE`
+#' @param bFlowchart `logical` Create flowchart to show data pipeline? Default: `FALSE`
 #'
 #' @examples
 #' \dontrun{
@@ -29,7 +30,8 @@ Study_Assess <- function(
   lMapping = NULL,
   lAssessments = NULL,
   lSubjFilters = NULL,
-  bQuiet = TRUE
+  bQuiet = TRUE,
+  bFlowchart = FALSE
 ) {
 
   #### --- load defaults --- ###
@@ -90,18 +92,24 @@ Study_Assess <- function(
       ### --- Attempt to run each assessment --- ###
       lAssessments <- lAssessments %>%
         purrr::map(function(lWorkflow) {
-          Runction <- ifelse(
-            hasName(lWorkflow, "group"),
-            RunStratifiedWorkflow,
-            RunWorkflow
-          )
 
-          Runction(
-            lWorkflow,
-            lData = lData,
-            lMapping = lMapping,
-            bQuiet = bQuiet
-          )
+          if (hasName(lWorkflow, "group")) {
+            RunStratifiedWorkflow(
+              lWorkflow,
+              lData = lData,
+              lMapping = lMapping,
+              bQuiet = bQuiet,
+              bFlowchart = bFlowchart
+            )
+          } else {
+            RunWorkflow(
+              lWorkflow,
+              lData = lData,
+              lMapping = lMapping,
+              bQuiet = bQuiet,
+              bFlowchart = bFlowchart
+            )
+          }
         })
     } else {
       if (!bQuiet) cli::cli_alert_danger("Subject-level data contains 0 rows. Assessment not run.")

--- a/R/util-RunStratifiedWorkflow.R
+++ b/R/util-RunStratifiedWorkflow.R
@@ -11,6 +11,7 @@
 #' `X_Map_Raw`.
 #' @param lMapping `list` A named list identifying the columns needed in each data domain.
 #' @param bQuiet `logical` Suppress warning messages? Default: `TRUE`
+#' @param bFlowchart `logical` Create flowchart to show data pipeline? Default: `FALSE`
 #'
 #' @return `list` `lWorkflow` along with `workflow`, `path`, `name`, `lData`, `lChecks`,
 #' `bStatus`, `checks`, and `lResults` added based on the results of the execution of
@@ -51,7 +52,8 @@ RunStratifiedWorkflow <- function(
   lWorkflow,
   lData,
   lMapping,
-  bQuiet = TRUE
+  bQuiet = TRUE,
+  bFlowchart = FALSE
 ) {
   if (!bQuiet) cli::cli_h1(paste0("Initializing `", lWorkflow$name, "` workflow"))
 
@@ -59,7 +61,8 @@ RunStratifiedWorkflow <- function(
     lWorkflow,
     lData,
     lMapping,
-    bQuiet = bQuiet
+    bQuiet = bQuiet,
+    bFlowchart = bFlowchart
   )
 
   if (

--- a/R/util-RunWorkflow.R
+++ b/R/util-RunWorkflow.R
@@ -8,6 +8,7 @@
 #' @param lData `list` A named list of domain-level data frames. Names should match the values specified in `lMapping` and `lAssessments`, which are generally based on the expected inputs from `X_Map_Raw`.
 #' @param lMapping `list` A named list identifying the columns needed in each data domain.
 #' @param bQuiet `logical` Suppress warning messages? Default: `TRUE`
+#' @param bFlowchart `logical` Create flowchart to show data pipeline? Default: `FALSE`
 #'
 #' @return `list` containing `lWorkflow` with `workflow`, `path`, `name`, `lData`, `lChecks`, `bStatus`, `checks`, and `lResults` added based on the results of the execution of `assessment$workflow`.
 #'
@@ -40,7 +41,7 @@
 #'
 #' @export
 
-RunWorkflow <- function(lWorkflow, lData, lMapping, bQuiet = TRUE) {
+RunWorkflow <- function(lWorkflow, lData, lMapping, bQuiet = TRUE, bFlowchart = FALSE) {
   if (!bQuiet) cli::cli_h1(paste0("Initializing `", lWorkflow$name, "` assessment"))
 
   vDataDomains <- purrr::map(lWorkflow$steps, function(x) {
@@ -94,9 +95,12 @@ RunWorkflow <- function(lWorkflow, lData, lMapping, bQuiet = TRUE) {
     lWorkflow$bStatus <- FALSE
   }
 
-  lWorkflow$lChecks$flowchart <- gsm::Visualize_Workflow(list(temp_name = lWorkflow)) %>%
-    purrr::set_names(nm = lWorkflow$name)
-  if (!bQuiet) cli::cli_alert_success("{.fn Visualize_Workflow} created a flowchart.")
+  if (bFlowchart) {
+    lWorkflow$lChecks$flowchart <- gsm::Visualize_Workflow(list(temp_name = lWorkflow)) %>%
+      purrr::set_names(nm = lWorkflow$name)
+    if (!bQuiet) cli::cli_alert_success("{.fn Visualize_Workflow} created a flowchart.")
+  }
+
 
 
   return(lWorkflow)

--- a/man/Make_Snapshot.Rd
+++ b/man/Make_Snapshot.Rd
@@ -23,7 +23,8 @@ Make_Snapshot(
   lAssessments = NULL,
   bUpdateParams = FALSE,
   cPath = NULL,
-  bQuiet = TRUE
+  bQuiet = TRUE,
+  bFlowchart = FALSE
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ See the Data Model Vignette - Appendix 2 - Data Model Specifications for detaile
 \item{cPath}{\code{character} a character string indicating a working directory to save .csv files; the output of the snapshot.}
 
 \item{bQuiet}{\code{logical} Suppress warning messages? Default: \code{TRUE}}
+
+\item{bFlowchart}{\code{logical} Create flowchart to show data pipeline? Default: \code{FALSE}}
 }
 \value{
 \code{list} \code{lSnapshot}, a named list with a data.frame for each component of the {gsm} data model.

--- a/man/RunStratifiedWorkflow.Rd
+++ b/man/RunStratifiedWorkflow.Rd
@@ -4,7 +4,13 @@
 \alias{RunStratifiedWorkflow}
 \title{Run a stratified workflow}
 \usage{
-RunStratifiedWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE)
+RunStratifiedWorkflow(
+  lWorkflow,
+  lData,
+  lMapping,
+  bQuiet = TRUE,
+  bFlowchart = FALSE
+)
 }
 \arguments{
 \item{lWorkflow}{\code{list} A named list of metadata defining how the workflow should be run.
@@ -17,6 +23,8 @@ specified in \code{lMapping} and \code{lAssessments}, which are generally based 
 \item{lMapping}{\code{list} A named list identifying the columns needed in each data domain.}
 
 \item{bQuiet}{\code{logical} Suppress warning messages? Default: \code{TRUE}}
+
+\item{bFlowchart}{\code{logical} Create flowchart to show data pipeline? Default: \code{FALSE}}
 }
 \value{
 \code{list} \code{lWorkflow} along with \code{workflow}, \code{path}, \code{name}, \code{lData}, \code{lChecks},

--- a/man/RunWorkflow.Rd
+++ b/man/RunWorkflow.Rd
@@ -4,7 +4,7 @@
 \alias{RunWorkflow}
 \title{Run a single assessment}
 \usage{
-RunWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE)
+RunWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE, bFlowchart = FALSE)
 }
 \arguments{
 \item{lWorkflow}{\code{list} A named list of metadata defining how each assessment should be run. Properties should include: \code{label} and \code{workflow}}
@@ -14,6 +14,8 @@ RunWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE)
 \item{lMapping}{\code{list} A named list identifying the columns needed in each data domain.}
 
 \item{bQuiet}{\code{logical} Suppress warning messages? Default: \code{TRUE}}
+
+\item{bFlowchart}{\code{logical} Create flowchart to show data pipeline? Default: \code{FALSE}}
 }
 \value{
 \code{list} containing \code{lWorkflow} with \code{workflow}, \code{path}, \code{name}, \code{lData}, \code{lChecks}, \code{bStatus}, \code{checks}, and \code{lResults} added based on the results of the execution of \code{assessment$workflow}.

--- a/man/Study_Assess.Rd
+++ b/man/Study_Assess.Rd
@@ -9,7 +9,8 @@ Study_Assess(
   lMapping = NULL,
   lAssessments = NULL,
   lSubjFilters = NULL,
-  bQuiet = TRUE
+  bQuiet = TRUE,
+  bFlowchart = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ Study_Assess(
 \item{lSubjFilters}{\code{list} a named list of parameters to filter subject-level data on.}
 
 \item{bQuiet}{\code{logical} Suppress warning messages? Default: \code{TRUE}}
+
+\item{bFlowchart}{\code{logical} Create flowchart to show data pipeline? Default: \code{FALSE}}
 }
 \value{
 \code{list} of assessments containing status information and results.

--- a/tests/testthat/_snaps/Make_Snapshot.md
+++ b/tests/testthat/_snaps/Make_Snapshot.md
@@ -100,5 +100,4 @@
       v Created 4 bar charts.
       v `AE_Assess()` Successful
       Saving lResults to `lWorkflow`
-      v `Visualize_Workflow()` created a flowchart.
 

--- a/tests/testthat/_snaps/Study_Assess.md
+++ b/tests/testthat/_snaps/Study_Assess.md
@@ -1036,10 +1036,6 @@
       
       
       
-      $flowchart
-      $flowchart$kri0001
-      
-      
 
 ---
 
@@ -1156,5 +1152,4 @@
       v Created 4 bar charts.
       v `AE_Assess()` Successful
       Saving lResults to `lWorkflow`
-      v `Visualize_Workflow()` created a flowchart.
 

--- a/tests/testthat/test_Visualize_Workflow.R
+++ b/tests/testthat/test_Visualize_Workflow.R
@@ -14,7 +14,9 @@ lData <- list(
   dfQUERY = dfQUERY
 )
 
-study <- Study_Assess(lData = lData, bQuiet = TRUE)
+lAssessments <- MakeWorkflowList(strNames = c("cou0002", "kri0007", "kri0009"))
+
+study <- Study_Assess(lData = lData, bQuiet = TRUE, bFlowchart = TRUE)
 
 
 test_that("flowchart is created for all assessments", {

--- a/tests/testthat/test_util-runAssessment.R
+++ b/tests/testthat/test_util-runAssessment.R
@@ -67,5 +67,5 @@ test_that("workflow with multiple FilterDomain steps is reported correctly", {
   sae_assessment <- RunWorkflow(lAssessments$sae, lData = lData, lMapping = lMapping, bQuiet = TRUE)
 
 
-  expect_equal(names(sae_assessment$lChecks), c("FilterDomain", "FilterDomain", "AE_Map_Raw", "AE_Assess", "flowchart"))
+  expect_equal(names(sae_assessment$lChecks), c("FilterDomain", "FilterDomain", "AE_Map_Raw", "AE_Assess"))
 })


### PR DESCRIPTION
## Overview
Fix #1006 

Adds `bFlowchart` parameter - defaults to not producing the `flowchart` object for each workflow found in `lChecks`. 
