### PR TITLE
Fix 639; 1025 - fix barcharts + warning during rcmd check

### DIFF
--- a/R/CheckSnapshotInputs.R
+++ b/R/CheckSnapshotInputs.R
@@ -26,8 +26,9 @@ CheckSnapshotInputs <- function(snapshot) {
   # get rbm_data_spec/data model
   gismo_input <- gsm::rbm_data_spec %>%
     filter(.data$System == "Gismo") %>%
-    arrange(match(.data$Table, names(snapshot))) %>%
-    split(.$Table)
+    arrange(match(.data$Table, names(snapshot)))
+
+  gismo_input <- split(gismo_input, gismo_input$Table)
 
   # expected tables ---------------------------------------------------------
 

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -120,7 +120,7 @@ Consent_Assess <- function(
     lCharts <- list()
 
     dfConfig <- MakeDfConfig(
-      strMethod = "identity",
+      strMethod = "Identity",
       strGroup = strGroup,
       strAbbreviation = "CONSENT",
       strMetric = "Consent Issues",
@@ -130,7 +130,7 @@ Consent_Assess <- function(
     )
 
     lCharts$barMetric <- gsm::Visualize_Score(dfSummary = lData$dfSummary, strType = "metric")
-    lCharts$barScore <- gsm::Visualize_Score(dfSummary = lData$dfSummary, strType = "score")
+    lCharts$barScore <- gsm::Visualize_Score(dfSummary = lData$dfSummary, strType = "score", vThreshold = nThreshold)
 
     lCharts$barMetricJS <- barChart(
       results = lData$dfSummary,

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -111,7 +111,7 @@ IE_Assess <- function(
     lCharts <- list()
 
     dfConfig <- MakeDfConfig(
-      strMethod = "identity",
+      strMethod = "Identity",
       strGroup = strGroup,
       strAbbreviation = "IE",
       strMetric = "Inclusion/Exclusion Issues",
@@ -120,8 +120,10 @@ IE_Assess <- function(
       vThreshold = nThreshold
     )
 
+
+
     lCharts$barMetric <- Visualize_Score(dfSummary = lData$dfSummary, strType = "metric")
-    lCharts$barScore <- Visualize_Score(dfSummary = lData$dfSummary, strType = "score")
+    lCharts$barScore <- Visualize_Score(dfSummary = lData$dfSummary, strType = "score", vThreshold = nThreshold)
 
     lCharts$barMetricJS <- barChart(
       results = lData$dfSummary,

--- a/R/Make_Snapshot.R
+++ b/R/Make_Snapshot.R
@@ -221,7 +221,7 @@ bFlowchart = FALSE
   # if `workflowid` is not found in the results, that means it was not run.
   status_workflow <- lMeta$config_workflow %>%
     left_join(parseStatus, by = "workflowid") %>%
-    mutate(status = ifelse(is.na(status), FALSE, status))
+    mutate(status = ifelse(is.na(.data$status), FALSE, .data$status))
 
   # parse warnings from is_mapping_valid to create an informative "notes" column
   warnings <- ParseWarnings(lResults)


### PR DESCRIPTION
## Overview
Fix #639 
Fix #1025 

Notes: 
- All flagged values for IE and Consent appear as yellow bars since there is only one threshold. We might want to set extreme threshold values or come up with another method of indicating flagged vs. abnormal counts of IE/Consent issues. 
- For now, left as-is since `{rbm-viz}` handles bar charts in the same way. 
- [Relevant issue here](https://github.com/Gilead-BioStats/gsm/issues/764#issuecomment-1387452203)


