### PR TITLE
Fix 1035 - add badge to documentation

### DIFF
--- a/R/AE_Assess.R
+++ b/R/AE_Assess.R
@@ -1,7 +1,10 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Adverse Event Assessment
 #'
 #' @description
 #' Evaluates adverse event (AE) rates to identify sites that may be over- or under-reporting AEs.
+#'
 #'
 #' @details
 #' The AE Assessment uses the standard [GSM data pipeline](

--- a/R/AE_Map_Adam.R
+++ b/R/AE_Map_Adam.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Adverse Event Assessment - ADaM Mapping
 #'
 #' @description

--- a/R/AE_Map_Raw.R
+++ b/R/AE_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Adverse Event Assessment - Raw Mapping
 #'
 #' @description

--- a/R/Analyze_Fisher.R
+++ b/R/Analyze_Fisher.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Fisher's Exact Test Analysis
 #'
 #' @details

--- a/R/Analyze_Identity.R
+++ b/R/Analyze_Identity.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Analyze Identity
 #'
 #' @details

--- a/R/Analyze_NormalApprox.R
+++ b/R/Analyze_NormalApprox.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Funnel Plot Analysis with Normal Approximation for Binary and Rate Outcomes
 #'
 #' @details

--- a/R/Analyze_NormalApprox_PredictBounds.R
+++ b/R/Analyze_NormalApprox_PredictBounds.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Funnel Plot Analysis with Normal Approximation - Predicted Boundaries
 #'
 #' @details

--- a/R/Analyze_Poisson.R
+++ b/R/Analyze_Poisson.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Poisson Analysis - Site Residuals
 #'
 #' @details

--- a/R/Analyze_Poisson_PredictBounds.R
+++ b/R/Analyze_Poisson_PredictBounds.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Poisson Analysis - Predicted Boundaries
 #'
 #' @details

--- a/R/Analyze_QTL.R
+++ b/R/Analyze_QTL.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' QTL Analysis
 #'
 #' @details

--- a/R/CheckSnapshotInputs.R
+++ b/R/CheckSnapshotInputs.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Check Snapshot Inputs
 #'
 #' @description

--- a/R/Consent_Assess.R
+++ b/R/Consent_Assess.R
@@ -1,6 +1,7 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Consent Assessment
 #'
-#' `r lifecycle::badge("experimental")`
 #'
 #' @description
 #' Evaluates sites where subject consent was:

--- a/R/Consent_Map_Raw.R
+++ b/R/Consent_Map_Raw.R
@@ -1,6 +1,7 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Consent Assessment - Raw Mapping
 #'
-#' `r lifecycle::badge("experimental")`
 #'
 #' @description
 #' Convert raw informed consent data, typically processed case report from data, to formatted

--- a/R/DataChg_Assess.R
+++ b/R/DataChg_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Data Change Rate Assessment
 #'
 #' @description

--- a/R/DataChg_Map_Raw.R
+++ b/R/DataChg_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Data Change Rate - Raw Mapping
 #'
 #' @description

--- a/R/DataEntry_Assess.R
+++ b/R/DataEntry_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Data Entry Lag Assessment
 #'
 #' @description

--- a/R/DataEntry_Map_Raw.R
+++ b/R/DataEntry_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Data Entry Lag - Raw Mapping
 #'
 #' @description

--- a/R/Disp_Assess.R
+++ b/R/Disp_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Disposition Assessment
 #'
 #' @description

--- a/R/Disp_Map_Raw.R
+++ b/R/Disp_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Disposition Assessment - Raw Mapping
 #'
 #' @description

--- a/R/ExportCode.R
+++ b/R/ExportCode.R
@@ -1,6 +1,7 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Export gsm analysis script using Data, Mapping, and Workflow
 #'
-#' `r lifecycle::badge("experimental")`
 #'
 #' @param lData `list` Raw+ data to use as inputs.
 #' @param lMapping `list` Standard mapping provided for [gsm::FilterDomain()] and `*_Map_Raw()` functions.

--- a/R/Flag.R
+++ b/R/Flag.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Flag
 #'
 #' Add columns flagging sites that represent possible statistical outliers when Identity statistical

--- a/R/Flag_Fisher.R
+++ b/R/Flag_Fisher.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Flag_Fisher
 #'
 #' Add columns flagging sites that represent possible statistical outliers when the Fisher's Exact Test is used.

--- a/R/Flag_NormalApprox.R
+++ b/R/Flag_NormalApprox.R
@@ -1,4 +1,6 @@
-#' Flag_Funnel
+#' `r lifecycle::badge("stable")`
+#'
+#' Flag_NormalApprox
 #'
 #' Add columns flagging sites that represent possible statistical outliers.
 #'

--- a/R/Flag_Poisson.R
+++ b/R/Flag_Poisson.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Flag_Poisson
 #'
 #' Add columns flagging sites that represent possible statistical outliers when the Poisson statistical method is used.

--- a/R/Flag_QTL.R
+++ b/R/Flag_QTL.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Flag QTL
 #'
 #' @details

--- a/R/Get_Enrolled.R
+++ b/R/Get_Enrolled.R
@@ -1,4 +1,6 @@
-#' {experimental} Get_Enrolled Calculated enrolled participants or sites.
+#' `r lifecycle::badge("stable")`
+#'
+#' Get_Enrolled Calculated enrolled participants or sites.
 #'
 #' @description
 #' Derive number of enrolled participants or sites by a given denominator (study or site).

--- a/R/IE_Assess.R
+++ b/R/IE_Assess.R
@@ -1,6 +1,6 @@
-#' Inclusion/Exclusion Assessment
+#' `r lifecycle::badge("stable")`
 #'
-#' `r lifecycle::badge("experimental")`
+#' Inclusion/Exclusion Assessment
 #'
 #' @description
 #' Evaluates sites exhibiting aberrant or excessive rates of unmet or missing inclusion/exclusion (IE) criteria.

--- a/R/LB_Assess.R
+++ b/R/LB_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Lab Abnormality Assessment
 #'
 #' @description

--- a/R/LB_Map_Raw.R
+++ b/R/LB_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Lab Abnormality Assessment - Raw Mapping
 #'
 #' @description

--- a/R/Make_Snapshot.R
+++ b/R/Make_Snapshot.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Make Snapshot - create and export Gizmo data model.
 #'
 #' @description

--- a/R/Overview_Table.R
+++ b/R/Overview_Table.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Overview Table - Create summary of red and amber KRIs for a study.
 #'
 #' @param lAssessments `list` The output of running [gsm::Study_Assess()]

--- a/R/PD_Assess_Binary.R
+++ b/R/PD_Assess_Binary.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Protocol Deviation Assessment
 #'
 #' @description

--- a/R/PD_Assess_Rate.R
+++ b/R/PD_Assess_Rate.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Protocol Deviation Assessment
 #'
 #' @description

--- a/R/PD_Map_Raw_Binary.R
+++ b/R/PD_Map_Raw_Binary.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Protocol Deviation Assessment - Raw Mapping
 #'
 #' @description

--- a/R/PD_Map_Raw_Rate.R
+++ b/R/PD_Map_Raw_Rate.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Protocol Deviation Assessment - Raw Mapping
 #'
 #' @description

--- a/R/QueryAge_Assess.R
+++ b/R/QueryAge_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Query Age Assessment
 #'
 #' @description

--- a/R/QueryAge_Map_Raw.R
+++ b/R/QueryAge_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Query Age - Raw Mapping
 #'
 #' @description

--- a/R/QueryRate_Assess.R
+++ b/R/QueryRate_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Query Rate Assessment
 #'
 #' @description

--- a/R/QueryRate_Map_Raw.R
+++ b/R/QueryRate_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Query Rate - Raw Mapping
 #'
 #' @description

--- a/R/RunQTL.R
+++ b/R/RunQTL.R
@@ -1,6 +1,5 @@
-#' {experimental} Run a QTL
-#'
 #' `r lifecycle::badge("experimental")`
+#'
 #'
 #' @description
 #' Run a QTL based on a pre-defined or custom workflow outside of `Make_Snapshot()` or `Study_Assess()`. This is a helper function that makes it possible to

--- a/R/SaveQTL.R
+++ b/R/SaveQTL.R
@@ -1,6 +1,6 @@
-#' {experimental} SaveQTL
-#'
 #' `r lifecycle::badge("experimental")`
+#'
+#' SaveQTL
 #'
 #' @description
 #' Save QTL analysis results to a directory location. The `strPath` argument specifies the filepath, including filename, of the current QTL analysis.

--- a/R/Screening_Assess.R
+++ b/R/Screening_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Screening Assessment
 #'
 #' @description

--- a/R/Screening_Map_Raw.R
+++ b/R/Screening_Map_Raw.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Screening Assessment - Raw Mapping
 #'
 #' @description

--- a/R/Study_Assess.R
+++ b/R/Study_Assess.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Run Multiple Assessments on a Study
 #'
 #' @description

--- a/R/Study_AssessmentReport.R
+++ b/R/Study_AssessmentReport.R
@@ -1,6 +1,7 @@
-#' {experimental} Make Summary of 1 or more assessment Data checks
-#'
 #' `r lifecycle::badge("experimental")`
+#'
+#' Make Summary of 1 or more assessment Data checks
+#'
 #'
 #' Make overview table with one row per assessment and one column per site showing flagged assessments.
 #'

--- a/R/Study_Report.R
+++ b/R/Study_Report.R
@@ -1,6 +1,7 @@
-#' {experimental} Study Report
-#'
 #' `r lifecycle::badge("experimental")`
+#'
+#' Study Report
+#'
 #'
 #' Create HTML summary report using the results of `Study_Assess`, including tables, charts, and error checking.
 #'

--- a/R/Summarize.R
+++ b/R/Summarize.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Make Summary Data Frame
 #'
 #' Create a concise summary of assessment results that is easy to aggregate across assessments

--- a/R/Transform_Count.R
+++ b/R/Transform_Count.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Transform Count
 #'
 #' Convert from input data format to needed input format to derive KRI for an Assessment. Calculate site-level count.

--- a/R/Transform_Rate.R
+++ b/R/Transform_Rate.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Transform Rate
 #'
 #' Convert from input data format to needed input format to derive KRI for an Assessment. Calculate a site-level rate.

--- a/R/UpdateParams.R
+++ b/R/UpdateParams.R
@@ -1,4 +1,6 @@
-#' {experimental} Update parameters for workflow
+#' `r lifecycle::badge("experimental")`
+#'
+#' Update parameters for workflow
 #'
 #' @param lWorkflow `list` Object returned by `MakeWorkflowList()`
 #' @param dfConfig `data.frame` Configuration parameters data.frame; `clindata::config_param`

--- a/R/Visualize_Scatter.R
+++ b/R/Visualize_Scatter.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Group-level visualization of group-level results
 #'
 #' @param dfSummary `data.frame` returned by [gsm::Summarize()]

--- a/R/Visualize_Score.R
+++ b/R/Visualize_Score.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Group-level visualization of scores.
 #'
 #' @param dfSummary `data.frame` returned by [gsm::Summarize()]

--- a/R/Visualize_Workflow.R
+++ b/R/Visualize_Workflow.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Flowchart visualization of data pipeline steps from filtering to summary data for an assessment workflow.
 #'
 #' @param lAssessments `list` A list of assessment-specific metadata.

--- a/R/barChart.R
+++ b/R/barChart.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' KRI Bar Chart
 #'
 #' @description

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' KRI Scatter Plot
 #'
 #' @description

--- a/R/util-CheckClindataMeta.R
+++ b/R/util-CheckClindataMeta.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Check gsm_version in clindata metadata
 #'
 #' @param config `list` Named list of metadata to check from the `{clindata}` package.

--- a/R/util-CheckInputs.R
+++ b/R/util-CheckInputs.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Check mapping inputs.
 #'
 #' @description

--- a/R/util-ConsolidateStrata.R
+++ b/R/util-ConsolidateStrata.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Consolidate stratified assessment outputs
 #'
 #' @description

--- a/R/util-FilterData.R
+++ b/R/util-FilterData.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Subset a data frame
 #'
 #' @description

--- a/R/util-FilterDomain.R
+++ b/R/util-FilterDomain.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Subset a data frame given a mapping
 #'
 #' @param df `data.frame` A data.frame to be filtered, likely within a mapping function.

--- a/R/util-MakeDfConfig.R
+++ b/R/util-MakeDfConfig.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Make dfConfig for use in {rbm-viz}
 #'
 #' @description

--- a/R/util-MakeStratifiedAssessment.R
+++ b/R/util-MakeStratifiedAssessment.R
@@ -1,4 +1,6 @@
-#' {experimental} Create multiple workflows from a single stratified workflow.
+#' `r lifecycle::badge("experimental")`
+#'
+#' Create multiple workflows from a single stratified workflow.
 #'
 #' @description
 #' `MakeStratifiedAssessment` is a utility function that creates a stratified workflow list using a pre-defined workflow (from `inst/workflows`), or

--- a/R/util-MakeWorkflowList.R
+++ b/R/util-MakeWorkflowList.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Load assessments from a package/directory
 #'
 #' @details

--- a/R/util-MergeSubjects.R
+++ b/R/util-MergeSubjects.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Merge Domain data with subject-level data
 #'
 #' @description

--- a/R/util-ParseWarnings.R
+++ b/R/util-ParseWarnings.R
@@ -1,4 +1,6 @@
-#' {experimental} Parse warnings from the result of Study_Assess.
+#' `r lifecycle::badge("experimental")`
+#'
+#' Parse warnings from the result of Study_Assess.
 #'
 #' @description
 #' `ParseWarnings` is used inside of `Make_Snapshot()` to summarize any issues with data needed to run a KRI or QTL. If there are any warnings for any

--- a/R/util-RemoveInvalidSubjectIDs.R
+++ b/R/util-RemoveInvalidSubjectIDs.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Remove invalid Subject IDs
 #'
 #' @description

--- a/R/util-RunStep.R
+++ b/R/util-RunStep.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Run a single step in a workflow
 #'
 #' @description

--- a/R/util-RunStratifiedWorkflow.R
+++ b/R/util-RunStratifiedWorkflow.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Run a stratified workflow
 #'
 #' @description

--- a/R/util-RunWorkflow.R
+++ b/R/util-RunWorkflow.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Run a single assessment
 #'
 #' @description

--- a/R/util-UpdateGSMVersion.R
+++ b/R/util-UpdateGSMVersion.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Update GSM Version
 #'
 #' @description

--- a/R/util-is_mapping_valid.R
+++ b/R/util-is_mapping_valid.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Check that a data frame contains columns and fields specified in mapping.
 #'
 #' @description

--- a/R/util-kri_directionality_logo.R
+++ b/R/util-kri_directionality_logo.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' KRI Directionality Logo
 #'
 #' @description

--- a/R/util-parse_data_mapping.R
+++ b/R/util-parse_data_mapping.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Parse Data Mapping
 #'
 #' Transform nested data mapping to tabular structure for use in documentation.

--- a/R/util-parse_data_spec.R
+++ b/R/util-parse_data_spec.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("stable")`
+#'
 #' Parse Data Specification
 #'
 #' Transform nested data specification to tabular structure for use in documentation.

--- a/R/util-rank_chg.R
+++ b/R/util-rank_chg.R
@@ -1,3 +1,5 @@
+#' `r lifecycle::badge("experimental")`
+#'
 #' Report Helper Functions
 #'
 #' @description

--- a/man/AE_Assess.Rd
+++ b/man/AE_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AE_Assess.R
 \name{AE_Assess}
 \alias{AE_Assess}
-\title{Adverse Event Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 AE_Assess(
   dfInput,
@@ -69,6 +69,8 @@ when \code{strMethod == "NormalApprox"} or \code{strMethod == "Poisson"}. \code{
 Evaluates adverse event (AE) rates to identify sites that may be over- or under-reporting AEs.
 }
 \details{
+Adverse Event Assessment
+
 The AE Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/AE_Map_Adam.Rd
+++ b/man/AE_Map_Adam.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AE_Map_Adam.R
 \name{AE_Map_Adam}
 \alias{AE_Map_Adam}
-\title{Adverse Event Assessment - ADaM Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 AE_Map_Adam(
   dfs = list(dfADSL = safetyData::adam_adsl, dfADAE = safetyData::adam_adae),
@@ -38,6 +38,8 @@ Convert analysis adverse event (AE) data, by default ADaM data, to formatted inp
 \code{\link[=AE_Assess]{AE_Assess()}}.
 }
 \details{
+Adverse Event Assessment - ADaM Mapping
+
 \code{AE_Map_Adam} combines AE data with subject-level treatment exposure data to create formatted
 input data to \code{\link[=AE_Assess]{AE_Assess()}}. This function creates an input dataset for the AE Assessment
 (\code{\link[=AE_Assess]{AE_Assess()}}) by binding subject-level AE counts (derived from \code{dfADAE}) to subject-level

--- a/man/AE_Map_Raw.Rd
+++ b/man/AE_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AE_Map_Raw.R
 \name{AE_Map_Raw}
 \alias{AE_Map_Raw}
-\title{Adverse Event Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 AE_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfAE = clindata::rawplus_ae),
@@ -39,6 +39,8 @@ Convert raw adverse event (AE) data, typically processed case report form data, 
 input data to \code{\link[=AE_Assess]{AE_Assess()}}.
 }
 \details{
+Adverse Event Assessment - Raw Mapping
+
 \code{AE_Map_Raw} combines AE data with subject-level treatment exposure data to create formatted
 input data to \code{\link[=AE_Assess]{AE_Assess()}}. This function creates an input dataset for the AE Assessment
 (\code{\link[=AE_Assess]{AE_Assess()}}) by binding subject-level AE counts (derived from \code{dfAE}) to subject-level

--- a/man/Analyze_Fisher.Rd
+++ b/man/Analyze_Fisher.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_Fisher.R
 \name{Analyze_Fisher}
 \alias{Analyze_Fisher}
-\title{Fisher's Exact Test Analysis}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_Fisher(dfTransformed, strOutcome = "Numerator", bQuiet = TRUE)
 }

--- a/man/Analyze_Identity.Rd
+++ b/man/Analyze_Identity.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_Identity.R
 \name{Analyze_Identity}
 \alias{Analyze_Identity}
-\title{Analyze Identity}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_Identity(dfTransformed, strValueCol = "Metric", bQuiet = TRUE)
 }

--- a/man/Analyze_NormalApprox.Rd
+++ b/man/Analyze_NormalApprox.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_NormalApprox.R
 \name{Analyze_NormalApprox}
 \alias{Analyze_NormalApprox}
-\title{Funnel Plot Analysis with Normal Approximation for Binary and Rate Outcomes}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_NormalApprox(dfTransformed, strType = "binary", bQuiet = TRUE)
 }

--- a/man/Analyze_NormalApprox_PredictBounds.Rd
+++ b/man/Analyze_NormalApprox_PredictBounds.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_NormalApprox_PredictBounds.R
 \name{Analyze_NormalApprox_PredictBounds}
 \alias{Analyze_NormalApprox_PredictBounds}
-\title{Funnel Plot Analysis with Normal Approximation - Predicted Boundaries}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_NormalApprox_PredictBounds(
   dfTransformed,

--- a/man/Analyze_Poisson.Rd
+++ b/man/Analyze_Poisson.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_Poisson.R
 \name{Analyze_Poisson}
 \alias{Analyze_Poisson}
-\title{Poisson Analysis - Site Residuals}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_Poisson(dfTransformed, bQuiet = TRUE)
 }

--- a/man/Analyze_Poisson_PredictBounds.Rd
+++ b/man/Analyze_Poisson_PredictBounds.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_Poisson_PredictBounds.R
 \name{Analyze_Poisson_PredictBounds}
 \alias{Analyze_Poisson_PredictBounds}
-\title{Poisson Analysis - Predicted Boundaries}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_Poisson_PredictBounds(
   dfTransformed,

--- a/man/Analyze_QTL.Rd
+++ b/man/Analyze_QTL.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Analyze_QTL.R
 \name{Analyze_QTL}
 \alias{Analyze_QTL}
-\title{QTL Analysis}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Analyze_QTL(
   dfTransformed,

--- a/man/CheckClindataMeta.Rd
+++ b/man/CheckClindataMeta.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-CheckClindataMeta.R
 \name{CheckClindataMeta}
 \alias{CheckClindataMeta}
-\title{Check gsm_version in clindata metadata}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 CheckClindataMeta(
   config = list(config_param = clindata::config_param, config_workflow =

--- a/man/CheckInputs.Rd
+++ b/man/CheckInputs.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-CheckInputs.R
 \name{CheckInputs}
 \alias{CheckInputs}
-\title{Check mapping inputs.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 CheckInputs(context, dfs, mapping = NULL, spec = NULL, bQuiet = TRUE)
 }
@@ -32,6 +32,9 @@ CheckInputs(context, dfs, mapping = NULL, spec = NULL, bQuiet = TRUE)
 \description{
 \code{CheckInputs()} uses a mapping and specification to recursively run the \code{{gsm}} function \code{is_mapping_valid()} on data domains for a given assessment.
 The purpose of \code{CheckInputs()} is to identify any issues where the input data does not match the pre-defined mapping and/or specification for the expected input data format.
+}
+\details{
+Check mapping inputs.
 }
 \examples{
 checks <- CheckInputs(

--- a/man/CheckSnapshotInputs.Rd
+++ b/man/CheckSnapshotInputs.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/CheckSnapshotInputs.R
 \name{CheckSnapshotInputs}
 \alias{CheckSnapshotInputs}
-\title{Check Snapshot Inputs}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 CheckSnapshotInputs(snapshot)
 }
@@ -21,6 +21,9 @@ CheckSnapshotInputs(snapshot)
 \description{
 Check that the output created from \code{\link[=Make_Snapshot]{Make_Snapshot()}} returns all expected tables and columns within tables as defined by the
 data model (\link{rbm_data_spec}).
+}
+\details{
+Check Snapshot Inputs
 }
 \examples{
 \dontrun{

--- a/man/Consent_Assess.Rd
+++ b/man/Consent_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Consent_Assess.R
 \name{Consent_Assess}
 \alias{Consent_Assess}
-\title{Consent Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Consent_Assess(
   dfInput,
@@ -62,7 +62,7 @@ Evaluates sites where subject consent was:
 }
 }
 \details{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Consent Assessment
 
 The Consent Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag sites with consent issues. This assessment detects sites with subjects who participated
 in study activities before consent was finalized. The count returned in the summary represents

--- a/man/Consent_Map_Raw.Rd
+++ b/man/Consent_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Consent_Map_Raw.R
 \name{Consent_Map_Raw}
 \alias{Consent_Map_Raw}
-\title{Consent Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 Consent_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfCONSENT = clindata::rawplus_consent),
@@ -39,7 +39,7 @@ Convert raw informed consent data, typically processed case report from data, to
 input data to \code{\link[=Consent_Assess]{Consent_Assess()}}.
 }
 \details{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Consent Assessment - Raw Mapping
 
 \code{Consent_Map_Raw} combines consent data with subject-level data to create formatted input data
 to \code{\link[=Consent_Assess]{Consent_Assess()}}. This function creates an input dataset for the Consent Assessment

--- a/man/ConsolidateStrata.Rd
+++ b/man/ConsolidateStrata.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-ConsolidateStrata.R
 \name{ConsolidateStrata}
 \alias{ConsolidateStrata}
-\title{Consolidate stratified assessment outputs}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 ConsolidateStrata(lOutput, lStratifiedOutput, bQuiet = TRUE)
 }
@@ -21,6 +21,9 @@ ConsolidateStrata(lOutput, lStratifiedOutput, bQuiet = TRUE)
 \description{
 Consolidates multiple stratified assessment outputs by stacking the data frames returned by an
 \verb{*_Assess} function and generating a paneled data visualization.
+}
+\details{
+Consolidate stratified assessment outputs
 }
 \examples{
 lData <- list(

--- a/man/DataChg_Assess.Rd
+++ b/man/DataChg_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/DataChg_Assess.R
 \name{DataChg_Assess}
 \alias{DataChg_Assess}
-\title{Data Change Rate Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 DataChg_Assess(
   dfInput,
@@ -67,6 +67,8 @@ of the column. Default: package-defined Labs Assessment mapping.}
 Evaluates rate of reported data point with >1 changes.
 }
 \details{
+Data Change Rate Assessment
+
 The Data Change Rate Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/DataChg_Map_Raw.Rd
+++ b/man/DataChg_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/DataChg_Map_Raw.R
 \name{DataChg_Map_Raw}
 \alias{DataChg_Map_Raw}
-\title{Data Change Rate - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 DataChg_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfDATACHG = clindata::edc_data_change_rate),
@@ -38,6 +38,8 @@ of the column.}
 Convert raw data entry data to formatted input data to \code{\link[=DataChg_Assess]{DataChg_Assess()}}.
 }
 \details{
+Data Change Rate - Raw Mapping
+
 \code{DataChg_Map_Raw} creates an input dataset for the Data Change Rate Assessment \code{\link[=DataChg_Assess]{DataChg_Assess()}} by adding
 Data Points with Change Counts (derived from \code{dfDATACHG}) to basic subject-level data (from \code{dfSUBJ}).
 }

--- a/man/DataEntry_Assess.Rd
+++ b/man/DataEntry_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/DataEntry_Assess.R
 \name{DataEntry_Assess}
 \alias{DataEntry_Assess}
-\title{Data Entry Lag Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 DataEntry_Assess(
   dfInput,
@@ -67,6 +67,8 @@ of the column. Default: package-defined Labs Assessment mapping.}
 Evaluates rate of reported Data Entry Lag >10 days.
 }
 \details{
+Data Entry Lag Assessment
+
 The Data Entry Lag Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/DataEntry_Map_Raw.Rd
+++ b/man/DataEntry_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/DataEntry_Map_Raw.R
 \name{DataEntry_Map_Raw}
 \alias{DataEntry_Map_Raw}
-\title{Data Entry Lag - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 DataEntry_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfDATAENT = clindata::edc_data_entry_lag),
@@ -38,6 +38,8 @@ of the column.}
 Convert raw data entry data to formatted input data to \code{\link[=DataEntry_Assess]{DataEntry_Assess()}}.
 }
 \details{
+Data Entry Lag - Raw Mapping
+
 \code{DataEntry_Map_Raw} creates an input dataset for the Data Entry Lag Assessment \code{\link[=DataEntry_Assess]{DataEntry_Assess()}} by adding
 Data Entry Lag Counts (derived from \code{dfDATAENT}) to basic subject-level data (from \code{dfSUBJ}).
 }

--- a/man/Disp_Assess.Rd
+++ b/man/Disp_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Disp_Assess.R
 \name{Disp_Assess}
 \alias{Disp_Assess}
-\title{Disposition Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Disp_Assess(
   dfInput,
@@ -70,6 +70,8 @@ of the column. Default: package-defined Disposition Assessment mapping.}
 Evaluates disposition rate (DISP) on mapped subject-level dataset to identify sites that may be over- or under-reporting patient discontinuations.
 }
 \details{
+Disposition Assessment
+
 The Disposition Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/Disp_Map_Raw.Rd
+++ b/man/Disp_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Disp_Map_Raw.R
 \name{Disp_Map_Raw}
 \alias{Disp_Map_Raw}
-\title{Disposition Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Disp_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfSTUDCOMP = clindata::rawplus_studcomp,
@@ -45,6 +45,8 @@ Convert raw disposition data to formatted input data to to formatted
 input data to \code{\link[=Disp_Assess]{Disp_Assess()}}.
 }
 \details{
+Disposition Assessment - Raw Mapping
+
 \code{Disp_Map_Raw} creates an input dataset for the Disposition Assessment \code{\link[=Disp_Assess]{Disp_Assess()}} by adding
 Discontinuation Reason Counts (derived from \code{dfDISP}) to basic subject-level data (from \code{dfSUBJ}).
 }

--- a/man/ExportCode.Rd
+++ b/man/ExportCode.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/ExportCode.R
 \name{ExportCode}
 \alias{ExportCode}
-\title{Export gsm analysis script using Data, Mapping, and Workflow}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 ExportCode(
   lData,
@@ -27,7 +27,7 @@ ExportCode(
 \item{strFileName}{\code{character} Name of file to save.}
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Export gsm analysis script using Data, Mapping, and Workflow
 }
 \examples{
 lData <- list(

--- a/man/FilterData.Rd
+++ b/man/FilterData.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-FilterData.R
 \name{FilterData}
 \alias{FilterData}
-\title{Subset a data frame}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 FilterData(dfInput, strCol, anyVal, bReturnChecks = FALSE, bQuiet = TRUE)
 }
@@ -24,6 +24,9 @@ FilterData(dfInput, strCol, anyVal, bReturnChecks = FALSE, bQuiet = TRUE)
 \code{FilterData} is used to select rows of a data.frame that satisfy a specified condition. \code{FilterData} is called within the \code{RunStep} function to subset available data
 for a stratified KRI on an existing categorical variable. For example, we can filter Adverse Event assessment data on the \code{aetoxgr} variable,
 which specifies if the adverse event was mild, moderate, or severe.
+}
+\details{
+Subset a data frame
 }
 \examples{
 

--- a/man/FilterDomain.Rd
+++ b/man/FilterDomain.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-FilterDomain.R
 \name{FilterDomain}
 \alias{FilterDomain}
-\title{Subset a data frame given a mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 FilterDomain(
   df,

--- a/man/Flag.Rd
+++ b/man/Flag.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Flag.R
 \name{Flag}
 \alias{Flag}
-\title{Flag}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Flag(dfAnalyzed, strColumn = "Score", vThreshold = NULL, strValueColumn = NULL)
 }
@@ -26,10 +26,12 @@ the value for that row is lower than the median of \code{strValueColumn}, then F
 \code{data.frame} with one row per site with columns: \code{GroupID}, \code{TotalCount}, \code{Metric}, \code{Score}, \code{Flag}
 }
 \description{
-Add columns flagging sites that represent possible statistical outliers when Identity statistical
-method is used.
+Flag
 }
 \details{
+Add columns flagging sites that represent possible statistical outliers when Identity statistical
+method is used.
+
 This function provides a generalized framework for flagging sites as part of the
 \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline}.
 }

--- a/man/Flag_Fisher.Rd
+++ b/man/Flag_Fisher.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Flag_Fisher.R
 \name{Flag_Fisher}
 \alias{Flag_Fisher}
-\title{Flag_Fisher}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Flag_Fisher(dfAnalyzed, vThreshold = NULL)
 }
@@ -15,9 +15,11 @@ Flag_Fisher(dfAnalyzed, vThreshold = NULL)
 \code{data.frame} with one row per site with columns: \code{GroupID}, \code{Numerator}, \code{Denominator}, \code{Numerator_Other}, \code{Denominator}, \code{Denominator_Other}, \code{Prop}, \code{Prop_Other}, \code{Metric}, \code{Estimate}, \code{Score}, \code{Flag}
 }
 \description{
-Add columns flagging sites that represent possible statistical outliers when the Fisher's Exact Test is used.
+Flag_Fisher
 }
 \details{
+Add columns flagging sites that represent possible statistical outliers when the Fisher's Exact Test is used.
+
 This function flags sites based on the Fisher's Exact Test result as part of the \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline}.
 }
 \section{Data Specification}{

--- a/man/Flag_NormalApprox.Rd
+++ b/man/Flag_NormalApprox.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Flag_NormalApprox.R
 \name{Flag_NormalApprox}
 \alias{Flag_NormalApprox}
-\title{Flag_Funnel}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Flag_NormalApprox(dfAnalyzed, vThreshold = NULL)
 }
@@ -16,9 +16,11 @@ values in strColumn are compared to vThreshold using strict comparisons. Values 
 \code{data.frame} with "Flag" column added
 }
 \description{
-Add columns flagging sites that represent possible statistical outliers.
+Flag_NormalApprox
 }
 \details{
+Add columns flagging sites that represent possible statistical outliers.
+
 This function flags sites based on the funnel plot with normal approximation analysis result as part of
 the \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline}.
 }

--- a/man/Flag_Poisson.Rd
+++ b/man/Flag_Poisson.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Flag_Poisson.R
 \name{Flag_Poisson}
 \alias{Flag_Poisson}
-\title{Flag_Poisson}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Flag_Poisson(dfAnalyzed, vThreshold = NULL)
 }
@@ -15,9 +15,11 @@ Flag_Poisson(dfAnalyzed, vThreshold = NULL)
 \code{data.frame} with one row per site with columns: \code{GroupID}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{PredictedCount}, \code{Flag}
 }
 \description{
-Add columns flagging sites that represent possible statistical outliers when the Poisson statistical method is used.
+Flag_Poisson
 }
 \details{
+Add columns flagging sites that represent possible statistical outliers when the Poisson statistical method is used.
+
 This function flags sites based on the Poisson analysis result as part of the \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline}.
 }
 \section{Data Specification}{

--- a/man/Flag_QTL.Rd
+++ b/man/Flag_QTL.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Flag_QTL.R
 \name{Flag_QTL}
 \alias{Flag_QTL}
-\title{Flag QTL}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Flag_QTL(dfAnalyzed, vThreshold = NULL)
 }

--- a/man/Get_Enrolled.Rd
+++ b/man/Get_Enrolled.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Get_Enrolled.R
 \name{Get_Enrolled}
 \alias{Get_Enrolled}
-\title{{experimental} Get_Enrolled Calculated enrolled participants or sites.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Get_Enrolled(dfSUBJ, dfConfig, lMapping, strUnit, strBy)
 }
@@ -22,6 +22,9 @@ Get_Enrolled(dfSUBJ, dfConfig, lMapping, strUnit, strBy)
 }
 \description{
 Derive number of enrolled participants or sites by a given denominator (study or site).
+}
+\details{
+Get_Enrolled Calculated enrolled participants or sites.
 }
 \examples{
 enrolled <- Get_Enrolled(

--- a/man/IE_Assess.Rd
+++ b/man/IE_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/IE_Assess.R
 \name{IE_Assess}
 \alias{IE_Assess}
-\title{Inclusion/Exclusion Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 IE_Assess(
   dfInput,
@@ -55,7 +55,7 @@ of the column. Default: package-defined Inclusion/Exclusion Assessment mapping.}
 Evaluates sites exhibiting aberrant or excessive rates of unmet or missing inclusion/exclusion (IE) criteria.
 }
 \details{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Inclusion/Exclusion Assessment
 
 The IE Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag sites with IE issues. This assessment detects sites with excessive rates of unmet or
 missing IE criteria, as defined by \code{nThreshold}. The count returned in the summary represents the

--- a/man/LB_Assess.Rd
+++ b/man/LB_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/LB_Assess.R
 \name{LB_Assess}
 \alias{LB_Assess}
-\title{Lab Abnormality Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 LB_Assess(
   dfInput,
@@ -66,6 +66,8 @@ of the column. Default: package-defined Labs Assessment mapping.}
 Evaluates rate of reported Lab Abnormalities (LB).
 }
 \details{
+Lab Abnormality Assessment
+
 The Lab Abnormality Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/LB_Map_Raw.Rd
+++ b/man/LB_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/LB_Map_Raw.R
 \name{LB_Map_Raw}
 \alias{LB_Map_Raw}
-\title{Lab Abnormality Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 LB_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfLB = clindata::rawplus_lb),
@@ -38,6 +38,8 @@ of the column. Default: package-defined mapping for raw+.}
 Convert from ADaM or raw format to input format for Lab Abnormality Assessment.
 }
 \details{
+Lab Abnormality Assessment - Raw Mapping
+
 Convert raw lab data (LB), typically processed case report form data, to formatted
 input data to \code{\link[=LB_Assess]{LB_Assess()}}.
 

--- a/man/MakeDfConfig.Rd
+++ b/man/MakeDfConfig.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-MakeDfConfig.R
 \name{MakeDfConfig}
 \alias{MakeDfConfig}
-\title{Make dfConfig for use in {rbm-viz}}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 MakeDfConfig(
   strMethod,
@@ -36,6 +36,9 @@ MakeDfConfig(
 \code{MakeDfConfig} is a utility function that is used within \verb{*_Assess()} functions in \code{{gsm}}.
 
 The output of \code{MakeDfConfig} is used as a configuration dataset for a \code{{rbm-viz}} htmlwidget.
+}
+\details{
+Make dfConfig for use in {rbm-viz}
 }
 \examples{
 \dontrun{

--- a/man/MakeStratifiedAssessment.Rd
+++ b/man/MakeStratifiedAssessment.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-MakeStratifiedAssessment.R
 \name{MakeStratifiedAssessment}
 \alias{MakeStratifiedAssessment}
-\title{{experimental} Create multiple workflows from a single stratified workflow.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 MakeStratifiedAssessment(lWorkflow, lData, lMapping, bQuiet = TRUE)
 }
@@ -26,6 +26,9 @@ For this example using default data, \code{MakeWorkflowList} will create four li
 \itemize{
 \item one with assessment results for mild AEs, one for moderate, one for severe, and one for life-threatening events.
 }
+}
+\details{
+Create multiple workflows from a single stratified workflow.
 }
 \examples{
 \dontrun{

--- a/man/MakeWorkflowList.Rd
+++ b/man/MakeWorkflowList.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-MakeWorkflowList.R
 \name{MakeWorkflowList}
 \alias{MakeWorkflowList}
-\title{Load assessments from a package/directory}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 MakeWorkflowList(
   strNames = NULL,

--- a/man/Make_Snapshot.Rd
+++ b/man/Make_Snapshot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Make_Snapshot.R
 \name{Make_Snapshot}
 \alias{Make_Snapshot}
-\title{Make Snapshot - create and export Gizmo data model.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Make_Snapshot(
   lMeta = list(config_param = clindata::config_param, config_workflow =
@@ -64,6 +64,9 @@ for the Gismo web application.
 
 For more context about the inputs and outputs of \code{Make_Snapshot()}, refer to the \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM Data Pipeline Vignette}, specifically
 Appendix 2 - Data Model Specifications
+}
+\details{
+Make Snapshot - create and export Gizmo data model.
 }
 \section{Return - Data Model Description}{
 A named \code{list} of data.frames:

--- a/man/MergeSubjects.Rd
+++ b/man/MergeSubjects.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-MergeSubjects.R
 \name{MergeSubjects}
 \alias{MergeSubjects}
-\title{Merge Domain data with subject-level data}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 MergeSubjects(
   dfDomain,
@@ -32,6 +32,9 @@ MergeSubjects(
 \description{
 \code{MergeSubjects} is a helper function used within mapping functions to join subject-level data with domain-level data, with the ability to impute
 zeros when necessary.
+}
+\details{
+Merge Domain data with subject-level data
 }
 \examples{
 MergeSubjects(

--- a/man/Overview_Table.Rd
+++ b/man/Overview_Table.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Overview_Table.R
 \name{Overview_Table}
 \alias{Overview_Table}
-\title{Overview Table - Create summary of red and amber KRIs for a study.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Overview_Table(lAssessments, bInteractive = TRUE)
 }

--- a/man/PD_Assess_Binary.Rd
+++ b/man/PD_Assess_Binary.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/PD_Assess_Binary.R
 \name{PD_Assess_Binary}
 \alias{PD_Assess_Binary}
-\title{Protocol Deviation Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 PD_Assess_Binary(
   dfInput,
@@ -71,6 +71,8 @@ of the column. Default: package-defined Protocol Deviation Assessment mapping.}
 Evaluates protocol deviation (PD) rates to identify sites that may be over- or under-reporting PDs.
 }
 \details{
+Protocol Deviation Assessment
+
 The PD Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/PD_Assess_Rate.Rd
+++ b/man/PD_Assess_Rate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/PD_Assess_Rate.R
 \name{PD_Assess_Rate}
 \alias{PD_Assess_Rate}
-\title{Protocol Deviation Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 PD_Assess_Rate(
   dfInput,
@@ -70,6 +70,8 @@ of the column. Default: package-defined Protocol Deviation Assessment mapping.}
 Evaluates protocol deviation (PD) rates to identify sites that may be over- or under-reporting PDs.
 }
 \details{
+Protocol Deviation Assessment
+
 The PD Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/PD_Map_Raw_Binary.Rd
+++ b/man/PD_Map_Raw_Binary.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/PD_Map_Raw_Binary.R
 \name{PD_Map_Raw_Binary}
 \alias{PD_Map_Raw_Binary}
-\title{Protocol Deviation Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 PD_Map_Raw_Binary(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfPD = clindata::rawplus_protdev),
@@ -39,6 +39,8 @@ Convert raw protocol deviation (PD) data, typically processed case report form d
 input data to \code{\link[=PD_Assess_Binary]{PD_Assess_Binary()}}.
 }
 \details{
+Protocol Deviation Assessment - Raw Mapping
+
 \code{PD_Map_Raw_Binary} combines PD data with subject-level study duration data to create formatted
 input data to \code{\link[=PD_Assess_Binary]{PD_Assess_Binary()}}. This function creates an input dataset for the PD Assessment
 (\code{\link[=PD_Assess_Binary]{PD_Assess_Binary()}}) by binding subject-level PD counts (derived from \code{dfPD}) to subject-level

--- a/man/PD_Map_Raw_Rate.Rd
+++ b/man/PD_Map_Raw_Rate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/PD_Map_Raw_Rate.R
 \name{PD_Map_Raw_Rate}
 \alias{PD_Map_Raw_Rate}
-\title{Protocol Deviation Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 PD_Map_Raw_Rate(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfPD = clindata::rawplus_protdev),
@@ -39,6 +39,8 @@ Convert raw protocol deviation (PD) data, typically processed case report form d
 input data to \code{\link[=PD_Assess_Rate]{PD_Assess_Rate()}}.
 }
 \details{
+Protocol Deviation Assessment - Raw Mapping
+
 \code{PD_Map_Raw_Rate} combines PD data with subject-level study duration data to create formatted
 input data to \code{\link[=PD_Assess_Rate]{PD_Assess_Rate()}}. This function creates an input dataset for the PD Assessment
 (\code{\link[=PD_Assess_Rate]{PD_Assess_Rate()}}) by binding subject-level PD counts (derived from \code{dfPD}) to subject-level

--- a/man/ParseWarnings.Rd
+++ b/man/ParseWarnings.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-ParseWarnings.R
 \name{ParseWarnings}
 \alias{ParseWarnings}
-\title{{experimental} Parse warnings from the result of Study_Assess.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 ParseWarnings(lResults)
 }
@@ -16,6 +16,9 @@ ParseWarnings(lResults)
 \code{ParseWarnings} is used inside of \code{Make_Snapshot()} to summarize any issues with data needed to run a KRI or QTL. If there are any warnings for any
 workflow run via \code{Make_Snapshot()}, they are appended to the \code{notes} column in the  \code{status_workflow} data.frame, which is included in the output
 of \code{Make_Snapshot()}. If there are no warnings, the \code{notes} column contains \code{NA} for all KRIs/QTLs.
+}
+\details{
+Parse warnings from the result of Study_Assess.
 }
 \examples{
 # Set all subjid to NA to create warnings

--- a/man/QueryAge_Assess.Rd
+++ b/man/QueryAge_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/QueryAge_Assess.R
 \name{QueryAge_Assess}
 \alias{QueryAge_Assess}
-\title{Query Age Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 QueryAge_Assess(
   dfInput,
@@ -67,6 +67,8 @@ of the column. Default: package-defined Labs Assessment mapping.}
 Evaluates rate of reported Query Age >30 days.
 }
 \details{
+Query Age Assessment
+
 The Query Age Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/QueryAge_Map_Raw.Rd
+++ b/man/QueryAge_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/QueryAge_Map_Raw.R
 \name{QueryAge_Map_Raw}
 \alias{QueryAge_Map_Raw}
-\title{Query Age - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 QueryAge_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfQUERY = clindata::edc_queries),
@@ -38,6 +38,8 @@ of the column.}
 Convert raw query data to formatted input data to \code{\link[=QueryAge_Assess]{QueryAge_Assess()}}.
 }
 \details{
+Query Age - Raw Mapping
+
 \code{QueryAge_Map_Raw} combines query data with data points data and subject-level data to create
 formatted input data to \code{\link[=QueryAge_Assess]{QueryAge_Assess()}}. This function creates an input dataset for the Query Age Assessment
 (\code{\link[=QueryAge_Assess]{QueryAge_Assess()}}) by binding subject-level query counts (derived from \code{dfQUERY}) to subject-level

--- a/man/QueryRate_Assess.Rd
+++ b/man/QueryRate_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/QueryRate_Assess.R
 \name{QueryRate_Assess}
 \alias{QueryRate_Assess}
-\title{Query Rate Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 QueryRate_Assess(
   dfInput,
@@ -69,6 +69,8 @@ when \code{strMethod == "NormalApprox"} or \code{strMethod == "Poisson"}. \code{
 Evaluates query rates to identify sites that may be over- or under-reporting queries.
 }
 \details{
+Query Rate Assessment
+
 The Query Rate Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/QueryRate_Map_Raw.Rd
+++ b/man/QueryRate_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/QueryRate_Map_Raw.R
 \name{QueryRate_Map_Raw}
 \alias{QueryRate_Map_Raw}
-\title{Query Rate - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 QueryRate_Map_Raw(
   dfs = list(dfSUBJ = clindata::rawplus_dm, dfQUERY = clindata::edc_queries, dfDATACHG =
@@ -40,6 +40,8 @@ of the column.}
 Convert raw query data to formatted input data to \code{\link[=QueryRate_Assess]{QueryRate_Assess()}}.
 }
 \details{
+Query Rate - Raw Mapping
+
 \code{QueryRate_Map_Raw} combines query data with data points data and subject-level data to create
 formatted input data to \code{\link[=QueryRate_Assess]{QueryRate_Assess()}}. This function creates an input dataset for the Query Rate Assessment
 (\code{\link[=QueryRate_Assess]{QueryRate_Assess()}}) by binding subject-level query counts (derived from \code{dfQUERY}) and data point counts

--- a/man/RemoveInvalidSubjectIDs.Rd
+++ b/man/RemoveInvalidSubjectIDs.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-RemoveInvalidSubjectIDs.R
 \name{RemoveInvalidSubjectIDs}
 \alias{RemoveInvalidSubjectIDs}
-\title{Remove invalid Subject IDs}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 RemoveInvalidSubjectIDs(
   df,
@@ -28,6 +28,9 @@ RemoveInvalidSubjectIDs(
 }
 \description{
 \code{RemoveInvalidSubjectIDs} is a helper function that allows a user to specify a character vector of \code{SubjectID}s to remove from input data.
+}
+\details{
+Remove invalid Subject IDs
 }
 \examples{
 RemoveInvalidSubjectIDs(

--- a/man/RunQTL.Rd
+++ b/man/RunQTL.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/RunQTL.R
 \name{RunQTL}
 \alias{RunQTL}
-\title{{experimental} Run a QTL}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 RunQTL(strName = NULL, lWorkflow = NULL, lData = NULL, lMapping = NULL)
 }
@@ -21,9 +21,6 @@ RunQTL(strName = NULL, lWorkflow = NULL, lData = NULL, lMapping = NULL)
 \description{
 Run a QTL based on a pre-defined or custom workflow outside of \code{Make_Snapshot()} or \code{Study_Assess()}. This is a helper function that makes it possible to
 run a QTL for any supported \verb{*_Assess} function.
-}
-\details{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 }
 \examples{
 qtl <- RunQTL("qtl0004")

--- a/man/RunStep.Rd
+++ b/man/RunStep.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-RunStep.R
 \name{RunStep}
 \alias{RunStep}
-\title{Run a single step in a workflow}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 RunStep(lStep, lMapping, lData, bQuiet)
 }
@@ -27,6 +27,9 @@ parameter with results from \code{is_mapping_vald} for each domain in \code{lSte
 \description{
 Runs a single step of an assessment workflow. Currently supports \code{Filter}, \code{Map}, and \code{Assess}
 functions.
+}
+\details{
+Run a single step in a workflow
 }
 \examples{
 lStep <- MakeWorkflowList()[["kri0001"]][["steps"]][[1]]

--- a/man/RunStratifiedWorkflow.Rd
+++ b/man/RunStratifiedWorkflow.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-RunStratifiedWorkflow.R
 \name{RunStratifiedWorkflow}
 \alias{RunStratifiedWorkflow}
-\title{Run a stratified workflow}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 RunStratifiedWorkflow(
   lWorkflow,
@@ -38,6 +38,9 @@ specified in \code{lMapping} and \code{lAssessments}, which are generally based 
 \description{
 Attempts to run a stratified workflow (\code{lWorkflow}) using shared data (\code{lData}) and metadata (\code{lMapping}).
 Calls \code{RunStep} for each item in \code{lWorkflow$workflow} and saves the results to \code{lWorkflow}
+}
+\details{
+Run a stratified workflow
 }
 \examples{
 lWorkflows <- MakeWorkflowList()

--- a/man/RunWorkflow.Rd
+++ b/man/RunWorkflow.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-RunWorkflow.R
 \name{RunWorkflow}
 \alias{RunWorkflow}
-\title{Run a single assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 RunWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE, bFlowchart = FALSE)
 }
@@ -25,6 +25,9 @@ RunWorkflow(lWorkflow, lData, lMapping, bQuiet = TRUE, bFlowchart = FALSE)
 \description{
 Attempts to run a single assessment (\code{lWorkflow}) using shared data (\code{lData}) and metadata (\code{lMapping}).
 Calls \code{RunStep} for each item in \code{lWorkflow$workflow} and saves the results to \code{lWorkflow}
+}
+\details{
+Run a single assessment
 }
 \examples{
 lAssessments <- MakeWorkflowList()

--- a/man/SaveQTL.Rd
+++ b/man/SaveQTL.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/SaveQTL.R
 \name{SaveQTL}
 \alias{SaveQTL}
-\title{{experimental} SaveQTL}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 SaveQTL(
   lSnapshot,
@@ -23,7 +23,7 @@ Running \code{SaveQTL} will save a new file with an added row for the single spe
 but will incorporate the run date for version control.
 }
 \details{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+SaveQTL
 }
 \examples{
 \dontrun{

--- a/man/Screening_Assess.Rd
+++ b/man/Screening_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Screening_Assess.R
 \name{Screening_Assess}
 \alias{Screening_Assess}
-\title{Screening Assessment}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Screening_Assess(
   dfInput,
@@ -70,6 +70,8 @@ of the column. Default: package-defined Screening Assessment mapping.}
 Evaluates screen failure rate (SF) on mapped subject-level dataset to identify sites that may be over- or under-reporting patient discontinuations.
 }
 \details{
+Screening Assessment
+
 The Screening Assessment uses the standard \href{https://silver-potato-cfe8c2fb.pages.github.io/articles/DataPipeline.html}{GSM data pipeline} to flag possible outliers. Additional details regarding the data pipeline and statistical
 methods are described below.
 }

--- a/man/Screening_Map_Raw.Rd
+++ b/man/Screening_Map_Raw.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Screening_Map_Raw.R
 \name{Screening_Map_Raw}
 \alias{Screening_Map_Raw}
-\title{Screening Assessment - Raw Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Screening_Map_Raw(
   dfs = list(dfENROLL = clindata::rawplus_enroll),
@@ -37,6 +37,8 @@ of the column. Default: package-defined mapping for raw+.}
 Convert raw screening data to formatted input data to \code{\link[=Screening_Assess]{Screening_Assess()}}.
 }
 \details{
+Screening Assessment - Raw Mapping
+
 \code{Screening_Map_Raw} creates an input dataset for the Screening Assessment
 \code{\link[=Screening_Assess]{Screening_Assess()}} by identifying Screen Failures (derived from \code{dfENROLL}).
 }

--- a/man/Study_Assess.Rd
+++ b/man/Study_Assess.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Study_Assess.R
 \name{Study_Assess}
 \alias{Study_Assess}
-\title{Run Multiple Assessments on a Study}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Study_Assess(
   lData = NULL,
@@ -31,6 +31,9 @@ Study_Assess(
 }
 \description{
 Attempts to run one or more assessments (\code{lAssessments}) using shared data (\code{lData}) and metadata (\code{lMapping}). By default, the sample \code{rawplus} data from the {clindata} package is used, and all assessments defined in \code{inst/workflow} are evaluated. Individual assessments are run using \code{gsm::RunAssessment()}
+}
+\details{
+Run Multiple Assessments on a Study
 }
 \examples{
 \dontrun{

--- a/man/Study_AssessmentReport.Rd
+++ b/man/Study_AssessmentReport.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Study_AssessmentReport.R
 \name{Study_AssessmentReport}
 \alias{Study_AssessmentReport}
-\title{{experimental} Make Summary of 1 or more assessment Data checks}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 Study_AssessmentReport(lAssessments, bViewReport = FALSE)
 }
@@ -15,7 +15,7 @@ Study_AssessmentReport(lAssessments, bViewReport = FALSE)
 \code{list} containing a \code{data.frame} summarizing the checks \code{dfSummary} and a \code{data.frame} listing all checks (\code{dfAllChecks}).
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Make Summary of 1 or more assessment Data checks
 }
 \details{
 Make overview table with one row per assessment and one column per site showing flagged assessments.

--- a/man/Study_Report.Rd
+++ b/man/Study_Report.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Study_Report.R
 \name{Study_Report}
 \alias{Study_Report}
-\title{{experimental} Study Report}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 Study_Report(lAssessments, strOutpath = NULL)
 }
@@ -15,7 +15,7 @@ Study_Report(lAssessments, strOutpath = NULL)
 HTML report of study data.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+Study Report
 }
 \details{
 Create HTML summary report using the results of \code{Study_Assess}, including tables, charts, and error checking.

--- a/man/Summarize.Rd
+++ b/man/Summarize.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Summarize.R
 \name{Summarize}
 \alias{Summarize}
-\title{Make Summary Data Frame}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Summarize(
   dfFlagged,
@@ -25,9 +25,11 @@ Simplified finding data.frame with columns for GroupID, Metric, Score, Flag
 when associated with a workflow.
 }
 \description{
-Create a concise summary of assessment results that is easy to aggregate across assessments
+Make Summary Data Frame
 }
 \details{
+Create a concise summary of assessment results that is easy to aggregate across assessments
+
 \code{Summarize} supports the input data (\code{dfFlagged}) from the \code{Flag} function.
 }
 \section{Data Specification}{

--- a/man/Transform_Count.Rd
+++ b/man/Transform_Count.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Transform_Count.R
 \name{Transform_Count}
 \alias{Transform_Count}
-\title{Transform Count}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Transform_Count(dfInput, strCountCol, strGroupCol = "SiteID")
 }
@@ -17,9 +17,11 @@ Transform_Count(dfInput, strCountCol, strGroupCol = "SiteID")
 \code{data.frame} with one row per site with columns \code{GroupID}, \code{TotalCount}, and \code{Metric.}
 }
 \description{
-Convert from input data format to needed input format to derive KRI for an Assessment. Calculate site-level count.
+Transform Count
 }
 \details{
+Convert from input data format to needed input format to derive KRI for an Assessment. Calculate site-level count.
+
 This function transforms data to prepare it for the analysis step. It is currently only sourced for the Consent and IE Assessments.
 }
 \section{Data Specification}{

--- a/man/Transform_Rate.Rd
+++ b/man/Transform_Rate.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Transform_Rate.R
 \name{Transform_Rate}
 \alias{Transform_Rate}
-\title{Transform Rate}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Transform_Rate(
   dfInput,
@@ -27,9 +27,11 @@ Transform_Rate(
 \code{data.frame} with one row per site with columns \code{GroupID}, \code{Numerator}, \code{Denominator}, and \code{Metric}.
 }
 \description{
-Convert from input data format to needed input format to derive KRI for an Assessment. Calculate a site-level rate.
+Transform Rate
 }
 \details{
+Convert from input data format to needed input format to derive KRI for an Assessment. Calculate a site-level rate.
+
 This function transforms data to prepare it for the analysis step. It is currently only sourced for the Adverse Event, Disposition, Labs, and Protocol Deviations Assessments.
 }
 \section{Data Specification}{

--- a/man/UpdateGSMVersion.Rd
+++ b/man/UpdateGSMVersion.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-UpdateGSMVersion.R
 \name{UpdateGSMVersion}
 \alias{UpdateGSMVersion}
-\title{Update GSM Version}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 UpdateGSMVersion(version = NULL)
 }
@@ -14,6 +14,9 @@ Updated metadata. Currently \link{meta_param} and \link{meta_workflow}
 }
 \description{
 Automatically updates metadata that relies on the current \code{{gsm}} version.
+}
+\details{
+Update GSM Version
 }
 \examples{
 \dontrun{

--- a/man/UpdateParams.Rd
+++ b/man/UpdateParams.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/UpdateParams.R
 \name{UpdateParams}
 \alias{UpdateParams}
-\title{{experimental} Update parameters for workflow}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 UpdateParams(lWorkflow, dfConfig, dfMeta)
 }
@@ -17,5 +17,5 @@ UpdateParams(lWorkflow, dfConfig, dfMeta)
 \code{list} lWorkflow - modified list.
 }
 \description{
-{experimental} Update parameters for workflow
+Update parameters for workflow
 }

--- a/man/Visualize_Scatter.Rd
+++ b/man/Visualize_Scatter.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Visualize_Scatter.R
 \name{Visualize_Scatter}
 \alias{Visualize_Scatter}
-\title{Group-level visualization of group-level results}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Visualize_Scatter(
   dfSummary,

--- a/man/Visualize_Score.Rd
+++ b/man/Visualize_Score.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Visualize_Score.R
 \name{Visualize_Score}
 \alias{Visualize_Score}
-\title{Group-level visualization of scores.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 Visualize_Score(
   dfSummary,

--- a/man/Visualize_Workflow.Rd
+++ b/man/Visualize_Workflow.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/Visualize_Workflow.R
 \name{Visualize_Workflow}
 \alias{Visualize_Workflow}
-\title{Flowchart visualization of data pipeline steps from filtering to summary data for an assessment workflow.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 Visualize_Workflow(lAssessments)
 }

--- a/man/barChart.Rd
+++ b/man/barChart.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/barChart.R
 \name{barChart}
 \alias{barChart}
-\title{KRI Bar Chart}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 barChart(
   results = NULL,
@@ -69,6 +69,9 @@ barChart(
 \description{
 A widget that displays a group-level bar chart based on the output of a KRI analysis.
 Bar charts are provided by default in any Assess function, and are suffixed with "JS" to indicate that they are an \code{htmlwidget} ported from the \code{rbm-viz} JavaScript library.
+}
+\details{
+KRI Bar Chart
 }
 \examples{
 

--- a/man/is_mapping_valid.Rd
+++ b/man/is_mapping_valid.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-is_mapping_valid.R
 \name{is_mapping_valid}
 \alias{is_mapping_valid}
-\title{Check that a data frame contains columns and fields specified in mapping.}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 is_mapping_valid(df, mapping, spec, bQuiet = TRUE)
 }
@@ -27,6 +27,9 @@ a list containing checks and a \code{status} and \code{warning} (if check does n
 \description{
 \code{is_mapping_valid} is a utility function that is a core feature of any assessment or workflow. This function evaluates the validity of input data based on
 a pre-defined, or user-defined mapping and specification.
+}
+\details{
+Check that a data frame contains columns and fields specified in mapping.
 }
 \examples{
 subj_mapping <- list(

--- a/man/kri_directionality_logo.Rd
+++ b/man/kri_directionality_logo.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-kri_directionality_logo.R
 \name{kri_directionality_logo}
 \alias{kri_directionality_logo}
-\title{KRI Directionality Logo}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 kri_directionality_logo(flag_value)
 }
@@ -11,4 +11,7 @@ kri_directionality_logo(flag_value)
 }
 \description{
 Reporting utility function to create fontawesome directionality logos within \code{DT::datatable()}
+}
+\details{
+KRI Directionality Logo
 }

--- a/man/parse_data_mapping.Rd
+++ b/man/parse_data_mapping.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-parse_data_mapping.R
 \name{parse_data_mapping}
 \alias{parse_data_mapping}
-\title{Parse Data Mapping}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 parse_data_mapping(content = NULL, file = NULL)
 }
@@ -12,5 +12,8 @@ parse_data_mapping(content = NULL, file = NULL)
 \item{file}{\code{character} file path of .yaml file}
 }
 \description{
+Parse Data Mapping
+}
+\details{
 Transform nested data mapping to tabular structure for use in documentation.
 }

--- a/man/parse_data_spec.Rd
+++ b/man/parse_data_spec.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-parse_data_spec.R
 \name{parse_data_spec}
 \alias{parse_data_spec}
-\title{Parse Data Specification}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 parse_data_spec(content = NULL, file = NULL)
 }
@@ -12,5 +12,8 @@ parse_data_spec(content = NULL, file = NULL)
 \item{file}{\code{character} file path of .yaml file}
 }
 \description{
+Parse Data Specification
+}
+\details{
 Transform nested data specification to tabular structure for use in documentation.
 }

--- a/man/rank_chg.Rd
+++ b/man/rank_chg.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/util-rank_chg.R
 \name{rank_chg}
 \alias{rank_chg}
-\title{Report Helper Functions}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}}
 \usage{
 rank_chg(status)
 }
@@ -13,4 +13,7 @@ rank_chg(status)
 \code{rank_chg} - inserts icons for status in {gt} table.
 
 Adopted from https://themockup.blog/posts/2020-10-31-embedding-custom-features-in-gt-tables/.
+}
+\details{
+Report Helper Functions
 }

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/scatterPlot.R
 \name{scatterPlot}
 \alias{scatterPlot}
-\title{KRI Scatter Plot}
+\title{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}}
 \usage{
 scatterPlot(
   results,
@@ -65,6 +65,9 @@ scatterPlot(
 \description{
 A widget that displays a group-level scatter plot based on the output of a KRI analysis.
 Scatter plots are provided by default in any Assess function, and are suffixed with "JS" to indicate that they are an \code{htmlwidget} ported from the \code{rbm-viz} JavaScript library.
+}
+\details{
+KRI Scatter Plot
 }
 \examples{
 ae <- AE_Map_Raw()


### PR DESCRIPTION
## Overview

Fix #1035

Adds lifecycle badge to most exported functions
- All qualified functions receive "stable" by default
- Used judgment to designate "stable" or "experimental" to all other functions
  - Generally, if a function is not yet qualified but has been used consistently over the past ~year, it is considered stable, otherwise the function is considered experimental.