### PR TITLE
Fix #1209: remove unneeded condition in `Analyze_NormalApprox()`

### DIFF
--- a/R/Analyze_NormalApprox.R
+++ b/R/Analyze_NormalApprox.R
@@ -88,7 +88,7 @@ Analyze_NormalApprox <- function(
     dfScore <- dfTransformed %>%
       mutate(
         vMu = sum(.data$Numerator) / sum(.data$Denominator),
-        z_0 = ifelse(.data$vMu == 0 | .data$vMu == 1,
+        z_0 = ifelse(.data$vMu == 0,
           0,
           (.data$Metric - .data$vMu) /
             sqrt(.data$vMu / .data$Denominator)


### PR DESCRIPTION
See #1209, original code could leads to all zero z-scores if estimated overall poisson rate `vMu` is 1+-(1.5e-8) in the R `all.equal()` sense, which is totally plausible unlike the case in binary outcome where the range of `vMu` need be (0, 1).

