### PR TITLE
Fix 1213 - `Get_Enrolled()` bugfix

### DIFF
--- a/R/Get_Enrolled.R
+++ b/R/Get_Enrolled.R
@@ -36,13 +36,18 @@ Get_Enrolled <- function(dfSUBJ, dfConfig, lMapping, strUnit, strBy) {
     "dfSUBJ is not a data.frame" = is.data.frame(dfSUBJ),
     "dfConfig is not a data.frame" = is.data.frame(dfConfig),
     "strUnit is not `participant` or `site`" = strUnit %in% c("participant", "site"),
-    "strBy is not `study` or `site`" = strBy %in% c("study", "site")
+    "strBy is not `study` or `site`" = strBy %in% c("study", "site"),
+    "lMapping does not contain strEnrollCol" = "strEnrollCol" %in% names(lMapping$dfSUBJ),
+    "lMapping does not contain strEnrollVal" = "strEnrollVal" %in% names(lMapping$dfSUBJ)
   )
 
   studyid <- unique(dfConfig$studyid)
 
   dm <- dfSUBJ %>%
-    filter(.data[[lMapping$dfSUBJ$strStudyCol]] == studyid)
+    filter(
+      .data[[lMapping$dfSUBJ$strStudyCol]] == studyid &
+      .data[[lMapping$dfSUBJ$strEnrollCol]] == lMapping$dfSUBJ$strEnrollVal
+      )
 
   if (strUnit == "participant" & strBy == "study") {
     enrolled <- dm %>%

--- a/R/util-ReportHelpers.R
+++ b/R/util-ReportHelpers.R
@@ -67,7 +67,11 @@ MakeStudyStatusTable <- function(status_study) {
     setNames(c("Parameter", "Value")) %>%
     rowwise() %>%
     mutate(
-      Value = ifelse(is.na(Value), Value, prettyNum(.data$Value, drop0trailing = TRUE))
+      Value = ifelse(
+        is.na(.data$Value),
+        .data$Value,
+        prettyNum(.data$Value, drop0trailing = TRUE)
+        )
     ) %>%
     ungroup() %>%
     left_join(

--- a/tests/testthat/testdata/data.R
+++ b/tests/testthat/testdata/data.R
@@ -1902,7 +1902,8 @@ dfSUBJ_expanded <- tibble::tribble(
   "AA-AA-000-0000", "139", "0479", 720, 679, "2011-08-08", "US", "0X052",
   "AA-AA-000-0000", "75", "0305", 708, 672, "2017-07-11", "China", "0X027",
   "AA-AA-000-0000", "5", "1099", 755, 755, "2015-08-11", "US", "0X167"
-) %>% dplyr::mutate(subject_nsv = subjid)
+) %>% dplyr::mutate(subject_nsv = subjid,
+                    enrollyn = "Y")
 
 dfAE_expanded <- tibble::tribble(
   ~subjid, ~treatmentemergent, ~aetoxgr, ~aeser,


### PR DESCRIPTION
## Overview
Fix #1213

- Adds `stopifnot()` logic to check that mapping contains values for the `strEnrollCol` and `strEnrollVal` keys. 
- Filters `dfSUBJ` on `enrollyn == "Y"` 

