### PR TITLE
Fix #1288 - Missing values in `dfSITE`

### DIFF
--- a/R/Overview_Table.R
+++ b/R/Overview_Table.R
@@ -170,16 +170,30 @@ Overview_Table <- function(
     if ("enrolled_participants" %in% names(dfSite)) {
       if (strReportType == "site") {
         overview_table[["Subjects"]] <- overview_table$Site %>%
-          map_int(~ dfSite %>%
-            filter(.data$siteid == .x) %>%
-            pull(.data$enrolled_participants))
-      } else {
+          map_int(~ {
+
+            if (.x %in% dfSite$siteid) {
+              dfSite %>%
+                filter(.data$siteid == .x) %>%
+                pull(.data$enrolled_participants)
+            } else {
+              return(NA)
+            }
+
+
+      })} else {
         dfCountry <- Country_Map_Raw(dfSite)
 
         overview_table[["Subjects"]] <- overview_table$Site %>%
-          map_int(~ dfCountry %>%
+          map_int(~ {
+            if (.x %in% dfCountry$country) {
+            dfCountry %>%
             filter(.data$country == .x) %>%
-            pull(.data$enrolled_participants))
+            pull(.data$enrolled_participants)
+            } else {
+              return(NA)
+            }
+        })
       }
 
       overview_table <- relocate(


### PR DESCRIPTION
## Overview
Fix #1288 
- Returns a blank value for <<group>> count if it is not located in the `dfSITE` dataset
  - This allows the user to review the report and correct missing data if needed, without the report throwing an error

