### PR TITLE
Release v1.8.1-rc2

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -11,9 +11,9 @@ navbar:
       text: Sample Reports
       menu:
       - text: Site Report
-        href: reports/StandardReportSite.html
+        href: articles/StandardReportSite.html
       - text: Country Report
-        href: reports/StandardReportCountry.html
+        href: articles/StandardReportCountry.html
     articles:
       text: Articles
       menu:


### PR DESCRIPTION
## Overview
Hotfix release to address `pkgdown` site from failing. 

I believe this is because the `/docs/` folder, which is `.gitignore`d, has standard folders where assets are kept. I can't find any documentation that supports a custom directory, so I am *hoping* that this fix resolves the issue of reports being 404'd.

