### PR TITLE
Fix 1347 tweak

### DIFF
--- a/R/Augment_Snapshot.R
+++ b/R/Augment_Snapshot.R
@@ -149,7 +149,14 @@ Augment_Snapshot <- function(
     lSnapshot[["lStackedSnapshots"]] <- stackedSnapshots
 
   } else {
-    lSnapshot[["lStackedSnapshots"]] <- lSnapshot$lSnapshot
+
+    lSnapshot[["lStackedSnapshots"]] <- lSnapshot$lSnapshot %>%
+      purrr::map(
+        ~.x %>%
+          mutate(
+            snapshot_date = as.Date(.data$gsm_analysis_date, "%Y-%m-%d")
+            )
+        )
   }
   return(lSnapshot)
 }

--- a/R/Augment_Snapshot.R
+++ b/R/Augment_Snapshot.R
@@ -30,11 +30,11 @@
 #'
 #' @export
 Augment_Snapshot <- function(
-  lSnapshot,
-  cPath,
-  vFolderNames = NULL,
-  bAppendTimeSeriesCharts = TRUE,
-  bAppendLongitudinalResults = TRUE
+    lSnapshot,
+    cPath,
+    vFolderNames = NULL,
+    bAppendTimeSeriesCharts = TRUE,
+    bAppendLongitudinalResults = TRUE
 ) {
   # TODO: alternatively accept the output of StackSnapshots?
   stackedSnapshots <- StackSnapshots(cPath, lSnapshot, vFolderNames)
@@ -148,11 +148,8 @@ Augment_Snapshot <- function(
 
     lSnapshot[["lStackedSnapshots"]] <- stackedSnapshots
 
-    return(lSnapshot)
   } else {
-    cli::cli_alert_warning(
-      " [{.fn Augment_Snapshot} not run.] "
-    )
-    return(NULL)
+    lSnapshot[["lStackedSnapshots"]] <- lSnapshot$lSnapshot
   }
+  return(lSnapshot)
 }

--- a/R/util-ExtractDirectoryPaths.R
+++ b/R/util-ExtractDirectoryPaths.R
@@ -25,18 +25,18 @@ ExtractDirectoryPaths <- function(cPath, file, include.partial.match = TRUE, ver
   missing <- directories[!has_file]
 
   if(!include.partial.match & length(missing) > 0){
-    mess <- glue::glue("\n Some or all files of interest missing within: {str_flatten(paste0('`', stringr::str_extract(missing, '([^/]+$)'), '`'), collapse = ', ')}")
+    mess <- glue::glue("\n Some or all files of interest missing within: {stringr::str_flatten(paste0('`', stringr::str_extract(missing, '([^/]+$)'), '`'), collapse = ', ')}")
     if(verbose) {warning(mess)}
   }
 
   if(include.partial.match & length(missing) > 0){
-    mess <- glue::glue("All files of interest missing within: {str_flatten(paste0('`', stringr::str_extract(missing, '([^/]+$)'), '`'), collapse = ', ')}")
+    mess <- glue::glue("All files of interest missing within: {stringr::str_flatten(paste0('`', stringr::str_extract(missing, '([^/]+$)'), '`'), collapse = ', ')}")
     if(verbose) {warning(mess)}
     for(i in 1:length(present)){
       part[i] <- any(!file %in% list.files(present[i]))
     }
     for(i in present[part]){
-      mess2 <- glue::glue("`{stringr::str_extract(i, '([^/]+$)')}` missing files: {str_flatten(paste0('`', file[!file %in% list.files(i)], '`'), collapse = ', ')}")
+      mess2 <- glue::glue("`{stringr::str_extract(i, '([^/]+$)')}` missing files: {stringr::str_flatten(paste0('`', file[!file %in% list.files(i)], '`'), collapse = ', ')}")
       if(verbose) {warning(mess2)}
     }
 

--- a/R/util-StackSnapshots.R
+++ b/R/util-StackSnapshots.R
@@ -26,10 +26,10 @@ StackSnapshots <- function(
   lSnapshot = NULL,
   vFolderNames = NULL
 ) {
+
   stopifnot(
     "[ cPath ] does not exist." = file.exists(cPath)
   )
-
 
 
   # Capture list of YYYY-MM-DD-formatted snapshot directoreis.
@@ -46,11 +46,12 @@ StackSnapshots <- function(
     snapshots <- snapshots[basename(snapshots) %in% vFolderNames]
   }
 
-  stop(
-    "[ cPath ] detected only one snapshot, or the directory contains no dated folders formatted YYYY-MM-DD." = length(snapshots) > 0
-  )
-
-
+  if (length(snapshots) == 0) {
+    cli::cli_alert_warning(
+      " [{cPath} only contains the most recent snapshot. {.fn Augment_Snapshot} not run.] "
+    )
+    return(NULL)
+  }
 
   gsm_tables <- c(
     "meta_param",

--- a/R/util-StackSnapshots.R
+++ b/R/util-StackSnapshots.R
@@ -48,7 +48,7 @@ StackSnapshots <- function(
 
   if (length(snapshots) == 0) {
     cli::cli_alert_warning(
-      " [{cPath} only contains the most recent snapshot. {.fn Augment_Snapshot} not run.] "
+      " [{cPath} only contains the most recent snapshot. {.fn StackSnapshots} not run.] "
     )
     return(NULL)
   }

--- a/R/util-StackSnapshots.R
+++ b/R/util-StackSnapshots.R
@@ -46,8 +46,8 @@ StackSnapshots <- function(
     snapshots <- snapshots[basename(snapshots) %in% vFolderNames]
   }
 
-  stopifnot(
-    "[ cPath ] contains no dated folders formatted YYYY-MM-DD." = length(snapshots) > 0
+  stop(
+    "[ cPath ] detected only one snapshot, or the directory contains no dated folders formatted YYYY-MM-DD." = length(snapshots) > 0
   )
 
 


### PR DESCRIPTION
## Overview

Adding to changes in #1347, this PR adds logic to exit `stackSnapshots()`/`Augment_Snapshot()` if a dated folder is not found and/or if the user attempts to run `Augment_Snapshot()` on a single snapshot. 
- `stackSnapshots()` returns `NULL` if folder is not found.
- `Augment_Snapshot()` returns `NULL` if `stackSnapshots()` returns `NULL`.

