### PR TITLE
fix bug for clickevent on timeseries chart

### DIFF
--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -108,7 +108,7 @@ Widget_TimeSeries <- function(
         htmltools::tags$label(siteSelectLabelValue),
         htmltools::tags$select(
           class = "site-select--time-series",
-          id = glue::glue("site-select--time-series_{lLabels$workflowid}"),
+          id = glue::glue("site-select--time-series_{unique(lLabels$workflowid)}"),
           purrr::map(
             c("None", uniqueSiteSelections),
             ~ htmltools::HTML(paste0(

--- a/inst/htmlwidgets/Widget_TimeSeries.js
+++ b/inst/htmlwidgets/Widget_TimeSeries.js
@@ -13,7 +13,7 @@ HTMLWidgets.widget({
         lLabels.clickCallback = function(d) {
             // Update site dropdown.
             const siteDropdown = document
-                .getElementById(`site-select--time-series_${workflow.workflowid}`)
+                .getElementById(`site-select--time-series_${lLabels.workflowid}`)
             siteDropdown.value = d.groupid;
 
             // Update chart (closure allows access to `instance` prior to initialization).


### PR DESCRIPTION
## Overview
Fix #1490 

JS for click event was trying to select an ID that was being duplicated because of missing `unique()` wrapper.

## Test Notes/Sample Code

To test:
- Create longitudinal snapshot
- Click on a scatter plot point in the timeseries chart and confirm that a trend line appears and that the drop-down element is updated correctly.

```r
snap_one <- Make_Snapshot(strAnalysisDate = "2022-01-01")
snap_two <- Make_Snapshot(strAnalysisDate = "2022-02-01", lPrevSnapshot = snap_one)

snap_two$lCharts$kri0001$timeSeriesContinuousJS
```

For reference, the bug can be seen on [`pkgdown`](https://gilead-biostats.github.io/gsm/StandardReportSite.html#_AE_Reporting_Rate_5)


