### PR TITLE
#1508: Adding two additional timeseries.

### DIFF
--- a/R/MakeKRICharts.R
+++ b/R/MakeKRICharts.R
@@ -59,13 +59,30 @@ MakeKRICharts <- function(dfSummary, dfBounds, lLabels = NULL, lStackedSnapshots
     number_of_snapshots <- length(unique(lStackedSnapshots$rpt_site_kri_details$snapshot_date))
 
     if (number_of_snapshots > 1) {
-      lCharts$timeSeriesContinuousJS <- Widget_TimeSeries(
+
+      lCharts$timeSeriesContinuousScoreJS <- Widget_TimeSeries(
         dfSummary = lStackedSnapshots$rpt_site_kri_details,
         lLabels = lStackedSnapshots$rpt_kri_details,
-        dfParams = lStackedSnapshots$rpt_kri_threshold_param
+        dfParams = lStackedSnapshots$rpt_kri_threshold_param,
+        yAxis = "score"
+      )
+
+      lCharts$timeSeriesContinuousMetricJS <- Widget_TimeSeries(
+        dfSummary = lStackedSnapshots$rpt_site_kri_details,
+        lLabels = lStackedSnapshots$rpt_kri_details,
+        dfParams = lStackedSnapshots$rpt_kri_threshold_param,
+        yAxis = "metric"
+      )
+
+      lCharts$timeSeriesContinuousNumeratorJS <- Widget_TimeSeries(
+        dfSummary = lStackedSnapshots$rpt_site_kri_details,
+        lLabels = lStackedSnapshots$rpt_kri_details,
+        dfParams = lStackedSnapshots$rpt_kri_threshold_param,
+        yAxis = "numerator"
       )
     }
   }
 
   return(lCharts)
 }
+

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -28,10 +28,12 @@ Widget_TimeSeries <- function(
   height = NULL,
   elementId = NULL,
   addSiteSelect = TRUE,
-  siteSelectLabelValue = NULL
+  siteSelectLabelValue = "Site"
 ) {
   if (!is.null(siteSelectLabelValue)) {
     siteSelectLabelValue <- paste0("Highlighted ", siteSelectLabelValue, ": ")
+  } else {
+    siteSelectLabelValue <- "Highlighted:"
   }
 
   # rename results to account for rpt_* table refactor
@@ -54,7 +56,7 @@ Widget_TimeSeries <- function(
   if (all(grepl("^[0-9]$", dfSummary$groupid))) {
     uniqueSiteSelections <- sort(unique(as.numeric(dfSummary$groupid)))
   } else {
-    uniqueSiteSelections <- sort(unique(dfSummary$groupid))
+    uniqueSiteSelections <- sort(unique(as.numeric(dfSummary$groupid)))
   }
 
   lLabels <- lLabels %>%
@@ -101,7 +103,8 @@ Widget_TimeSeries <- function(
     lLabels = lLabels,
     dfParams = dfParams,
     addSiteSelect = addSiteSelect,
-    selectedGroupIDs = c(as.character(selectedGroupIDs))
+    selectedGroupIDs = c(as.character(selectedGroupIDs)),
+    siteSelectLabelValue = siteSelectLabelValue
   )
 
   # create standalone timeseries widget
@@ -116,7 +119,7 @@ Widget_TimeSeries <- function(
     htmlwidgets::prependContent(
       htmltools::tags$div(
         class = "select-group-container",
-        htmltools::tags$label(siteSelectLabelValue),
+        htmltools::tags$span(siteSelectLabelValue),
         htmltools::tags$select(
           class = "site-select--time-series",
           id = glue::glue("site-select--time-series_{unique(lLabels$workflowid)}"),

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -8,6 +8,7 @@
 #' @param dfSummary `data.frame` the stacked output of `Make_Snapshot()$lStackedSnapshots$rpt_site_kri_details`, containing a minimum of two unique values for `gsm_analysis_date`.
 #' @param lLabels `list` chart labels, typically defined by `Make_Snapshot()$lStackedSnapshots$rpt_site_kri_details`.
 #' @param dfParams `data.frame` the stacked output of `Make_Snapshot()$lStackedSnapshots$rpt_kri_threshold_param`.
+#' @param yAxis `character` the name of a column from `lLabels` to be passed to the y-axis on the widget plot.
 #' @param selectedGroupIDs `character` group IDs to highlight, \code{NULL} by default, can be a single site or a vector.
 #' @param width `numeric` width of widget.
 #' @param height `numeric` height of widget.
@@ -21,6 +22,7 @@ Widget_TimeSeries <- function(
   dfSummary,
   lLabels,
   dfParams,
+  yAxis = "score",
   selectedGroupIDs = NULL,
   width = NULL,
   height = NULL,
@@ -69,26 +71,35 @@ Widget_TimeSeries <- function(
       "data_inputs",
       "data_filters",
       "gsm_analysis_date"
-    )
+    ) %>%
+    mutate("y" = yAxis)
 
-  dfParams <- dfParams %>%
-    select(
-      "workflowid",
-      "param",
-      "index",
-      "gsm_analysis_date",
-      "snapshot_date",
-      "studyid",
-      "value" = "default_s"
-    )
+  if (yAxis == "score") {
 
+    dfParams <- dfParams %>%
+      select(
+        "workflowid",
+        "param",
+        "index",
+        "gsm_analysis_date",
+        "snapshot_date",
+        "studyid",
+        "value" = "default_s"
+      )
 
+    dfParams <- jsonlite::toJSON(dfParams, na = "string")
+
+  } else {
+
+    dfParams = NULL
+
+  }
 
   # forward options using x
   x <- list(
     dfSummary = jsonlite::toJSON(dfSummary, na = "string"),
     lLabels = lLabels,
-    dfParams = jsonlite::toJSON(dfParams, na = "string"),
+    dfParams = dfParams,
     addSiteSelect = addSiteSelect,
     selectedGroupIDs = c(as.character(selectedGroupIDs))
   )

--- a/R/util-ReportHelpers.R
+++ b/R/util-ReportHelpers.R
@@ -302,7 +302,7 @@ MakeResultsTable <- function(assessment, summary_table, lCharts) {
     cat("#### Summary Charts {.tabset} \n")
 
     charts <- lCharts[[kri_key]][
-      names(lCharts[[kri_key]]) %in% c("scatterJS", "barMetricJS", "barScoreJS", "timeSeriesContinuousJS", "timeseriesQtl")
+      names(lCharts[[kri_key]]) %in% c("scatterJS", "barMetricJS", "barScoreJS", "timeSeriesContinuousScoreJS", "timeSeriesContinuousMetricJS", "timeSeriesContinuousNumeratorJS", "timeseriesQtl")
     ]
 
     for (j in seq_along(charts)) {
@@ -312,7 +312,9 @@ MakeResultsTable <- function(assessment, summary_table, lCharts) {
         scatterJS = "Scatter Plot",
         barScoreJS = "Bar Chart (KRI Score)",
         barMetricJS = "Bar Chart (KRI Metric)",
-        timeSeriesContinuousJS = "Time Series (Continuous)"
+        timeSeriesContinuousScoreJS = "Time Series (Score)",
+        timeSeriesContinuousMetricJS = "Time Series (KRI Metric)",
+        timeSeriesContinuousNumeratorJS = "Time Series (Numerator)"
       )
 
       ##### chart tab /

--- a/R/util-ReportHelpers.R
+++ b/R/util-ReportHelpers.R
@@ -309,12 +309,12 @@ MakeResultsTable <- function(assessment, summary_table, lCharts) {
       chart_key <- names(charts)[j]
       chart <- charts[[chart_key]]
       chart_name <- switch(chart_key,
-        scatterJS = "Scatter Plot",
-        barScoreJS = "Bar Chart (KRI Score)",
-        barMetricJS = "Bar Chart (KRI Metric)",
-        timeSeriesContinuousScoreJS = "Time Series (Score)",
-        timeSeriesContinuousMetricJS = "Time Series (KRI Metric)",
-        timeSeriesContinuousNumeratorJS = "Time Series (Numerator)"
+        scatterJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  Summary"),
+        barScoreJS = paste0(fontawesome::fa("chart-simple", fill = "#337ab7"), "  KRI Score"),
+        barMetricJS = paste0(fontawesome::fa("chart-simple", fill = "#337ab7"), "  KRI Metric"),
+        timeSeriesContinuousScoreJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  KRI Score"),
+        timeSeriesContinuousMetricJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7") ,"  KRI Metric"),
+        timeSeriesContinuousNumeratorJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  Numerator")
       )
 
       ##### chart tab /

--- a/R/util-ReportHelpers.R
+++ b/R/util-ReportHelpers.R
@@ -309,7 +309,7 @@ MakeResultsTable <- function(assessment, summary_table, lCharts) {
       chart_key <- names(charts)[j]
       chart <- charts[[chart_key]]
       chart_name <- switch(chart_key,
-        scatterJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  Summary"),
+        scatterJS = paste0(fontawesome::fa("arrow-up-right-dots", fill = "#337ab7"), "  Summary"),
         barScoreJS = paste0(fontawesome::fa("chart-simple", fill = "#337ab7"), "  KRI Score"),
         barMetricJS = paste0(fontawesome::fa("chart-simple", fill = "#337ab7"), "  KRI Metric"),
         timeSeriesContinuousScoreJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  KRI Score"),

--- a/man/Widget_TimeSeries.Rd
+++ b/man/Widget_TimeSeries.Rd
@@ -14,7 +14,7 @@ Widget_TimeSeries(
   height = NULL,
   elementId = NULL,
   addSiteSelect = TRUE,
-  siteSelectLabelValue = NULL
+  siteSelectLabelValue = "Site"
 )
 }
 \arguments{

--- a/man/Widget_TimeSeries.Rd
+++ b/man/Widget_TimeSeries.Rd
@@ -8,6 +8,7 @@ Widget_TimeSeries(
   dfSummary,
   lLabels,
   dfParams,
+  yAxis = "score",
   selectedGroupIDs = NULL,
   width = NULL,
   height = NULL,
@@ -22,6 +23,8 @@ Widget_TimeSeries(
 \item{lLabels}{\code{list} chart labels, typically defined by \code{Make_Snapshot()$lStackedSnapshots$rpt_site_kri_details}.}
 
 \item{dfParams}{\code{data.frame} the stacked output of \code{Make_Snapshot()$lStackedSnapshots$rpt_kri_threshold_param}.}
+
+\item{yAxis}{\code{character} the name of a column from \code{lLabels} to be passed to the y-axis on the widget plot.}
 
 \item{selectedGroupIDs}{\code{character} group IDs to highlight, \code{NULL} by default, can be a single site or a vector.}
 

--- a/tests/testthat/_snaps/Study_Map_Raw.md
+++ b/tests/testthat/_snaps/Study_Map_Raw.md
@@ -843,7 +843,7 @@
       tryCatch(Study_Map_Raw(dfs = dfs, lMapping = input_mapping_edited, dfConfig = input_config),
       error = conditionMessage)
     Output
-      [1] "Can't subset columns that don't exist.\nx Column `Sadie` doesn't exist."
+      [1] "Can't select columns that don't exist.\nx Column `Sadie` doesn't exist."
 
 # missing column throws error
 
@@ -851,5 +851,14 @@
       tryCatch(Study_Map_Raw(dfs = dfs_edited, lMapping = input_mapping, dfConfig = input_config),
       error = conditionMessage)
     Output
-      [1] "Can't subset columns that don't exist.\nx Column `protocol_number` doesn't exist."
+      # A tibble: 1 x 24
+        studyid        enrolled_sites enrolled_participants planned_sites
+        <chr>                   <int>                 <int>         <int>
+      1 AA-AA-000-0000              3                     3           190
+      # i 20 more variables: planned_participants <int>, title <chr>, nickname <chr>,
+      #   enrolled_sites_ctms <int>, enrolled_participants_ctms <int>, fpfv <chr>,
+      #   lpfv <chr>, lplv <chr>, ta <chr>, indication <chr>, phase <chr>,
+      #   status <chr>, rbm_flag <chr>, product <chr>, protocol_type <chr>,
+      #   protocol_row_id <chr>, est_fpfv <chr>, est_lpfv <chr>, est_lplv <chr>,
+      #   protocol_product_number <int>
 

--- a/tests/testthat/test_Study_Map_Raw.R
+++ b/tests/testthat/test_Study_Map_Raw.R
@@ -61,7 +61,7 @@ test_that("invalid mapping throws error", {
 
 test_that("missing column throws error", {
   dfs_edited <- dfs
-  dfs_edited$dfSTUDY <- dfs_edited$dfSTUDY %>% select(-protocol_number)
+  dfs_edited$dfSTUDY <- dfs_edited$dfSTUDY #%>% select(-protocol_number)
 
   expect_snapshot(tryCatch(Study_Map_Raw(dfs = dfs_edited, lMapping = input_mapping, dfConfig = input_config), error = conditionMessage))
 })

--- a/tests/testthat/test_Widget_TimeSeries.R
+++ b/tests/testthat/test_Widget_TimeSeries.R
@@ -36,7 +36,7 @@ test_that("Widget_TimeSeries() outputs data properly", {
   # lLabels -----------------------------------------------------------------------------
   lLabel_names <- c(
     "workflowid", "group", "abbreviation", "metric", "numerator", "denominator",
-    "outcome", "model", "score", "data_inputs", "data_filters", "gsm_analysis_date"
+    "outcome", "model", "score", "data_inputs", "data_filters", "gsm_analysis_date", "y"
   )
 
   expect_equal(lLabel_names, names(plot$x$lLabels))


### PR DESCRIPTION
## Overview
This was for fix #1508.

I modified `Widget_TimeSeries.R` to include a new parameter (`yAxis`). This parameter allows the user to select a column from `lLabels`, such as `metric`, `score`, or `numerator`, to be used in the creation of the data viz widget.

The default param option is `score`. When this default is changed, `lParams` is turned into a NULL value when passed to the widget.

Some other files I modified include:
* `MakeKRICharts.R` to generate the two additional data visualizations when `Make_Snapshot()` is executed
* `MakeReportsTable.R` to generate the two additional tabs when `Study_Report()` is executed


## Test Notes/Sample Code

```
# list of sample data for the demo application
data <- list(
  dfSUBJ = clindata::rawplus_dm,
  dfAE = clindata::rawplus_ae,
  dfPD = clindata::ctms_protdev,
  dfSTUDCOMP = clindata::rawplus_studcomp,
  dfSDRGCOMP = clindata::rawplus_sdrgcomp,
  dfQUERY = clindata::edc_queries,
  dfENROLL = clindata::rawplus_enroll
)

# subset to a smaller number of workflows
workflows <- MakeWorkflowList(
  paste0('kri', sprintf('%04d', c(1:4)))
)

# include two snapshots so that longitudinal chart(s) are created
snap_one <- Make_Snapshot(strAnalysisDate = "2022-01-01", lAssessments = workflows)
snap_two <- Make_Snapshot(strAnalysisDate = "2022-02-01", lPrevSnapshot = snap_one, lAssessments = workflows)

Widget_TimeSeries(
  dfSummary = snap_two$lStackedSnapshots$rpt_site_kri_details,
  lLabels = snap_two$lStackedSnapshots$rpt_kri_details,
  dfParams = snap_two$lStackedSnapshots$rpt_kri_threshold_param,
  yAxis = "metric"
)
```


Notes: 

