### PR TITLE
Remove references to unused columns in mapping functions and specs.

### DIFF
--- a/R/Disp_Map_Raw.R
+++ b/R/Disp_Map_Raw.R
@@ -74,7 +74,6 @@ Disp_Map_Raw <- function(
     dfDISP_mapped <- dfDISP %>%
       select(
         SubjectID = lMapping[[strDomain]][["strIDCol"]],
-        DCReason = lMapping[[strDomain]][[glue::glue("str{strContext}DiscontinuationReasonCol")]],
         Discontinuation = lMapping[[strDomain]][[glue::glue("str{strContext}DiscontinuationFlagCol")]]
       ) %>%
       filter(.data$Discontinuation %in% lMapping[[strDomain]][[glue::glue("str{strContext}DiscontinuationFlagVal")]]) %>%

--- a/R/QueryRate_Map_Raw.R
+++ b/R/QueryRate_Map_Raw.R
@@ -64,26 +64,19 @@ QueryRate_Map_Raw <- function(
   if (checks$status) {
     if (!bQuiet) cli::cli_h2("Initializing {.fn QueryRate_Map_Raw}")
     # Standarize Column Names
-
-
-
     dfQUERY_mapped <- dfs$dfQUERY %>%
       select(
-        SubjectID = lMapping[["dfQUERY"]][["strIDCol"]],
-        VisitID = lMapping[["dfQUERY"]][["strVisitCol"]],
-        FormID = lMapping[["dfQUERY"]][["strFormCol"]]
+        SubjectID = lMapping[["dfQUERY"]][["strIDCol"]]
       ) %>%
-      group_by(.data$SubjectID, .data$VisitID, .data$FormID) %>%
+      group_by(.data$SubjectID) %>%
       summarize(Count = n()) %>%
       ungroup()
 
     dfDATACHG_mapped <- dfs$dfDATACHG %>%
       select(
-        SubjectID = lMapping[["dfDATACHG"]][["strIDCol"]],
-        VisitID = lMapping[["dfDATACHG"]][["strVisitCol"]],
-        FormID = lMapping[["dfDATACHG"]][["strFormCol"]]
+        SubjectID = lMapping[["dfDATACHG"]][["strIDCol"]]
       ) %>%
-      group_by(.data$SubjectID, .data$VisitID, .data$FormID) %>%
+      group_by(.data$SubjectID) %>%
       summarize(DataPoint = n()) %>%
       ungroup()
 
@@ -105,7 +98,7 @@ QueryRate_Map_Raw <- function(
     dfInput <- dfQUERY_mapped %>%
       full_join(
         dfDATACHG_mapped,
-        c("SubjectID", "VisitID", "FormID")
+        c("SubjectID")
       ) %>%
       group_by(.data$SubjectID) %>%
       summarize(

--- a/R/Screening_Map_Raw.R
+++ b/R/Screening_Map_Raw.R
@@ -71,8 +71,7 @@ Screening_Map_Raw <- function(
           )
         ),
         SubjectID = lMapping[["dfENROLL"]][["strIDCol"]],
-        ScreenFail = lMapping[["dfENROLL"]][["strScreenFailCol"]],
-        ScreenFailReason = lMapping[["dfENROLL"]][["strScreenFailReasonCol"]]
+        ScreenFail = lMapping[["dfENROLL"]][["strScreenFailCol"]]
       ) %>%
       mutate(
         Count = as.numeric(

--- a/inst/specs/Disp_Map_Raw_Study.yaml
+++ b/inst/specs/Disp_Map_Raw_Study.yaml
@@ -1,10 +1,8 @@
 dfSTUDCOMP:
   vRequired:
     - strIDCol
-    - strStudyDiscontinuationReasonCol
     - strStudyDiscontinuationFlagCol
   vNACols:
-    - strStudyDiscontinuationReasonCol
     - strStudyDiscontinuationFlagCol
 dfSUBJ:
   vRequired:

--- a/inst/specs/Disp_Map_Raw_Treatment.yaml
+++ b/inst/specs/Disp_Map_Raw_Treatment.yaml
@@ -1,10 +1,8 @@
 dfSDRGCOMP:
   vRequired:
     - strIDCol
-    - strTreatmentDiscontinuationReasonCol
     - strTreatmentDiscontinuationFlagCol
   vNACols:
-    - strTreatmentDiscontinuationReasonCol
     - strTreatmentDiscontinuationFlagCol
 dfSUBJ:
   vRequired:

--- a/inst/specs/QueryRate_Map_Raw.yaml
+++ b/inst/specs/QueryRate_Map_Raw.yaml
@@ -1,17 +1,9 @@
 dfQUERY:
   vRequired:
     - strIDCol
-    - strVisitCol
-    - strFormCol
-  vNACols:
-    - strVisitCol
 dfDATACHG:
   vRequired:
     - strIDCol
-    - strVisitCol
-    - strFormCol
-  vNACols:
-    - strVisitCol
 dfSUBJ:
   vRequired:
     - strEDCIDCol

--- a/inst/specs/Screening_Map_Raw.yaml
+++ b/inst/specs/Screening_Map_Raw.yaml
@@ -3,7 +3,5 @@ dfENROLL:
     - strSiteCol
     - strIDCol
     - strScreenFailCol
-    - strScreenFailReasonCol
   vNACols:
     - strScreenFailCol
-    - strScreenFailReasonCol

--- a/man/md/Disp_Map_Raw_Study.md
+++ b/man/md/Disp_Map_Raw_Study.md
@@ -1,9 +1,8 @@
 # Data specification
 
-|**Domain** |**Column Key**                   |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
-|:----------|:--------------------------------|:-----------------|:-------------|:---------------------------|:--------------------------|
-|dfSUBJ     |strSiteCol                       |siteid            |TRUE          |FALSE                       |FALSE                      |
-|dfSUBJ     |strIDCol                         |subjid            |TRUE          |FALSE                       |TRUE                       |
-|dfSTUDCOMP |strIDCol                         |subjid            |TRUE          |FALSE                       |FALSE                      |
-|dfSTUDCOMP |strStudyDiscontinuationFlagCol   |compyn            |TRUE          |TRUE                        |FALSE                      |
-|dfSTUDCOMP |strStudyDiscontinuationReasonCol |compreas          |TRUE          |TRUE                        |FALSE                      |
+|**Domain** |**Column Key**                 |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
+|:----------|:------------------------------|:-----------------|:-------------|:---------------------------|:--------------------------|
+|dfSUBJ     |strSiteCol                     |siteid            |TRUE          |FALSE                       |FALSE                      |
+|dfSUBJ     |strIDCol                       |subjid            |TRUE          |FALSE                       |TRUE                       |
+|dfSTUDCOMP |strIDCol                       |subjid            |TRUE          |FALSE                       |FALSE                      |
+|dfSTUDCOMP |strStudyDiscontinuationFlagCol |compyn            |TRUE          |TRUE                        |FALSE                      |

--- a/man/md/Disp_Map_Raw_Treatment.md
+++ b/man/md/Disp_Map_Raw_Treatment.md
@@ -1,9 +1,8 @@
 # Data specification
 
-|**Domain** |**Column Key**                       |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
-|:----------|:------------------------------------|:-----------------|:-------------|:---------------------------|:--------------------------|
-|dfSUBJ     |strSiteCol                           |siteid            |TRUE          |FALSE                       |FALSE                      |
-|dfSUBJ     |strIDCol                             |subjid            |TRUE          |FALSE                       |TRUE                       |
-|dfSDRGCOMP |strIDCol                             |subjid            |TRUE          |FALSE                       |FALSE                      |
-|dfSDRGCOMP |strTreatmentDiscontinuationFlagCol   |sdrgyn            |TRUE          |TRUE                        |FALSE                      |
-|dfSDRGCOMP |strTreatmentDiscontinuationReasonCol |sdrgreas          |TRUE          |TRUE                        |FALSE                      |
+|**Domain** |**Column Key**                     |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
+|:----------|:----------------------------------|:-----------------|:-------------|:---------------------------|:--------------------------|
+|dfSUBJ     |strSiteCol                         |siteid            |TRUE          |FALSE                       |FALSE                      |
+|dfSUBJ     |strIDCol                           |subjid            |TRUE          |FALSE                       |TRUE                       |
+|dfSDRGCOMP |strIDCol                           |subjid            |TRUE          |FALSE                       |FALSE                      |
+|dfSDRGCOMP |strTreatmentDiscontinuationFlagCol |sdrgyn            |TRUE          |TRUE                        |FALSE                      |

--- a/man/md/QueryRate_Map_Raw.md
+++ b/man/md/QueryRate_Map_Raw.md
@@ -1,12 +1,8 @@
 # Data specification
 
-|**Domain** |**Column Key** |**Default Value** |**Required?** |**Accept NA/Empty Values?** |**Require Unique Values?** |
-|:----------|:--------------|:-----------------|:-------------|:---------------------------|:--------------------------|
-|dfSUBJ     |strSiteCol     |siteid            |TRUE          |FALSE                       |FALSE                      |
-|dfSUBJ     |strEDCIDCol    |subject_nsv       |TRUE          |FALSE                       |TRUE                       |
-|dfQUERY    |strIDCol       |subjectname       |TRUE          |FALSE                       |FALSE                      |
-|dfQUERY    |strVisitCol    |visit             |TRUE          |TRUE                        |FALSE                      |
-|dfQUERY    |strFormCol     |formoid           |TRUE          |FALSE                       |FALSE                      |
-|dfDATACHG  |strIDCol       |subjectname       |TRUE          |FALSE                       |FALSE                      |
-|dfDATACHG  |strVisitCol    |visit             |TRUE          |TRUE                        |FALSE                      |
-|dfDATACHG  |strFormCol     |formoid           |TRUE          |FALSE                       |FALSE                      |
+|**Domain** |**Column Key** |**Default Value** |**Required?** |**Require Unique Values?** |
+|:----------|:--------------|:-----------------|:-------------|:--------------------------|
+|dfSUBJ     |strSiteCol     |siteid            |TRUE          |FALSE                      |
+|dfSUBJ     |strEDCIDCol    |subject_nsv       |TRUE          |TRUE                       |
+|dfQUERY    |strIDCol       |subjectname       |TRUE          |FALSE                      |
+|dfDATACHG  |strIDCol       |subjectname       |TRUE          |FALSE                      |

--- a/man/md/Screening_Map_Raw.md
+++ b/man/md/Screening_Map_Raw.md
@@ -1,8 +1,7 @@
 # Data specification
 
-|**Domain** |**Column Key**         |**Default Value** |**Required?** |**Accept NA/Empty Values?** |
-|:----------|:----------------------|:-----------------|:-------------|:---------------------------|
-|dfENROLL   |strSiteCol             |siteid            |TRUE          |FALSE                       |
-|dfENROLL   |strIDCol               |subjectid         |TRUE          |FALSE                       |
-|dfENROLL   |strScreenFailCol       |enrollyn          |TRUE          |TRUE                        |
-|dfENROLL   |strScreenFailReasonCol |sfreas            |TRUE          |TRUE                        |
+|**Domain** |**Column Key**   |**Default Value** |**Required?** |**Accept NA/Empty Values?** |
+|:----------|:----------------|:-----------------|:-------------|:---------------------------|
+|dfENROLL   |strSiteCol       |siteid            |TRUE          |FALSE                       |
+|dfENROLL   |strIDCol         |subjectid         |TRUE          |FALSE                       |
+|dfENROLL   |strScreenFailCol |enrollyn          |TRUE          |TRUE                        |


### PR DESCRIPTION
## Overview
Resolves #1520 and relates to an [rbmLibrary issue](https://github.com/Gilead-BioStats/rbmLibrary/issues/51). For database query optimization best to eliminate as many columns as possible.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

