### PR TITLE
Format flags properly with Report_FormatFlag.

### DIFF
--- a/R/Report_FormatFlag.R
+++ b/R/Report_FormatFlag.R
@@ -13,16 +13,17 @@
 #' @export
 Report_FormatFlag <- function(flag_value, title = NULL) {
   rlang::check_installed("fontawesome", reason = "to use `Report_FormatFlag()`")
-  fa_titled <- function(name, fill) {
-    fontawesome::fa(name, fill = fill, title = title)
-  }
   fa_vector <- vector("character", length = length(flag_value))
-  fa_vector[is.na(flag_value)] <- fa_titled("minus", "#AAA") # gray
-  fa_vector[flag_value == -2] <- fa_titled("angles-down", "#FF5859") # red
-  fa_vector[flag_value == -1] <- fa_titled("angle-down", "#FEAA02") # yellow
-  fa_vector[flag_value == 0] <- fa_titled("check", "#3DAF06") # green
-  fa_vector[flag_value == -1] <- fa_titled("angle-up", "#FEAA02") # yellow
-  fa_vector[flag_value == -2] <- fa_titled("angles-up", "#FF5859") # red
+  fa_vector[is.na(flag_value)] <- fa_titled("minus", "#AAA", title) # gray
+  fa_vector[flag_value == -2] <- fa_titled("angles-down", "#FF5859", title) # red
+  fa_vector[flag_value == -1] <- fa_titled("angle-down", "#FEAA02", title) # yellow
+  fa_vector[flag_value == 0] <- fa_titled("check", "#3DAF06", title) # green
+  fa_vector[flag_value == 1] <- fa_titled("angle-up", "#FEAA02", title) # yellow
+  fa_vector[flag_value == 2] <- fa_titled("angles-up", "#FF5859", title) # red
 
   return(fa_vector)
+}
+
+fa_titled <- function(name, fill, title) {
+  fontawesome::fa(name, fill = fill, title = title)
 }

--- a/tests/testthat/test-Report_FormatFlag.R
+++ b/tests/testthat/test-Report_FormatFlag.R
@@ -1,0 +1,12 @@
+test_that("Report_FormatFlag formats all expected values", {
+  local_mocked_bindings(
+    fa_titled = function(name, fill, title) {
+      name
+    }
+  )
+  flag_value <- c(NA, -2, -1, 0, 1, 2)
+  expect_identical(
+    Report_FormatFlag(flag_value),
+    c("minus", "angles-down", "angle-down", "check", "angle-up", "angles-up")
+  )
+})


### PR DESCRIPTION
## Overview
Fixed typo in Report_FormatFlag() that was causing it to show negatives as positive and to not format positives.
Closes #1713

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

