### PR TITLE
Fix workflow typo.

### DIFF
--- a/.github/workflows/pkgdown-dev.yaml
+++ b/.github/workflows/pkgdown-dev.yaml
@@ -1,6 +1,6 @@
 on:
-   push:
-     branches: dev
+  push:
+    branches: dev
   workflow_dispatch:
 
 name: pkgdown-dev


### PR DESCRIPTION
## Overview
Despite what I said in #1734, this doesn't appear to be triggered specifically because of the dev-to-main PR; it just looked like it because that PR "changes" whenever something merges into dev. What's really happening here is that there was a typo, which was causing this workflow to never actually (successfully) run (except once or twice early on when I was testing things).

Closes #1734.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

