### PR TITLE
fix #1749

### DIFF
--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -10,6 +10,7 @@
 #' @param vThreshold `numeric` Threshold values.
 #' @param strOutcome `character` Outcome variable. Default: 'Score'.
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
+#' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.
 #'
 #' @examples
 #' ## Filter data to one metric and snapshot
@@ -23,8 +24,9 @@
 #' ## Make chart
 #' Widget_BarChart(
 #'   dfResults = reportingResults_filter,
+#'   dfGroups = reportingGroups,
 #'   lMetric = reportingMetrics_filter,
-#'   vThreshold = reportingMetrics$Threshold
+#'   vThreshold = reportingMetrics_filter$Threshold
 #' )
 #'
 #' @export
@@ -36,6 +38,7 @@ Widget_BarChart <- function(
   vThreshold = NULL,
   strOutcome = "Score",
   bAddGroupSelect = TRUE,
+  strShinyGroupSelectID = 'GroupID',
   bDebug = FALSE
 ) {
   # Parse `vThreshold` from comma-delimited character string to numeric vector.
@@ -58,6 +61,7 @@ Widget_BarChart <- function(
     vThreshold = vThreshold,
     strOutcome = strOutcome,
     bAddGroupSelect = bAddGroupSelect,
+    strShinyGroupSelectID = strShinyGroupSelectID,
     bDebug = bDebug
   )
 

--- a/R/Widget_ScatterPlot.R
+++ b/R/Widget_ScatterPlot.R
@@ -8,6 +8,7 @@
 #'
 #' @inheritParams shared-params
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
+#' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.
 #'
 #' @examples
 #' ## Filter data to one metric and snapshot
@@ -36,6 +37,7 @@ Widget_ScatterPlot <- function(
   dfGroups = NULL,
   dfBounds = NULL,
   bAddGroupSelect = TRUE,
+  strShinyGroupSelectID = 'GroupID',
   bDebug = FALSE
 ) {
   # define widget inputs
@@ -45,6 +47,7 @@ Widget_ScatterPlot <- function(
     dfGroups = dfGroups,
     dfBounds = dfBounds,
     bAddGroupSelect = bAddGroupSelect,
+    strShinyGroupSelectID = strShinyGroupSelectID,
     bDebug = bDebug
   )
 

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -10,22 +10,22 @@
 #' @param vThreshold `numeric` Threshold value(s).
 #' @param strOutcome `character` Outcome variable. Default: 'Score'.
 #' @param bAddGroupSelect `logical` Add a dropdown to highlight sites? Default: `TRUE`.
+#' @param strShinyGroupSelectID `character` Element ID of group select in Shiny context. Default: `'GroupID'`.
 #'
 #' @examples
 #' ## Filter data to one metric
 #' reportingResults_filter <- reportingResults %>%
 #'   dplyr::filter(MetricID == "kri0001")
-#'
+#' 
 #' reportingMetrics_filter <- reportingMetrics %>%
 #'   dplyr::filter(MetricID == "kri0001") %>%
 #'   as.list()
-#'
-#'
+#' 
 #' Widget_TimeSeries(
 #'   dfResults = reportingResults_filter,
 #'   lMetric = reportingMetrics_filter,
 #'   dfGroups = reportingGroups,
-#'   vThreshold = c(-3, -2, 2, 3)
+#'   vThreshold = reportingMetrics_filter$Threshold
 #' )
 #'
 #' @export
@@ -37,6 +37,7 @@ Widget_TimeSeries <- function(
   vThreshold = NULL,
   strOutcome = "Score",
   bAddGroupSelect = TRUE,
+  strShinyGroupSelectID = 'GroupID',
   bDebug = FALSE
 ) {
   # Parse `vThreshold` from comma-delimited character string to numeric vector.
@@ -59,6 +60,7 @@ Widget_TimeSeries <- function(
     vThreshold = vThreshold,
     strOutcome = strOutcome,
     bAddGroupSelect = bAddGroupSelect,
+    strShinyGroupSelectID = strShinyGroupSelectID,
     bDebug = bDebug
   )
 

--- a/inst/htmlwidgets/Widget_BarChart.js
+++ b/inst/htmlwidgets/Widget_BarChart.js
@@ -10,45 +10,14 @@ HTMLWidgets.widget({
                 // Assign a unique ID to the element.
                 el.id = `barChart--${input.lMetric.MetricID}_${input.strOutcome}`;
 
-                // Update y-axis variable.
-                input.lMetric.y = input.strOutcome;
-
                 // Add click event listener to chart.
-                if (input.bAddGroupSelect)
-                    input.lMetric.clickCallback = function(d) {
-                        instance.data.config.selectedGroupIDs = instance.data.config.selectedGroupIDs.includes(d.GroupID)
-                            ? 'None'
-                            : d.GroupID;
-
-                        // Update group select.
-                        groupSelect.value = instance.data.config.selectedGroupIDs;
-
-                        // Set country select to 'None' if a group ID is selected.
-                        if (countrySelect)
-                            countrySelect.value = "None";
-
-                        instance.helpers.updateConfig(
-                            instance,
-                            instance.data.config,
-                            instance.data._thresholds_
-                        );
-
-                        // Update Shiny input if in Shiny environment.
-                        if (typeof Shiny !== 'undefined') {
-                          if (instance.data.config.selectedGroupIDs.length > 0) {
-                            Shiny.setInputValue(
-                              'site',
-                              instance.data.config.selectedGroupIDs
-                            )
-                          }
-                        }
-                  };
+                input.lMetric.clickCallback = clickCallback(el, input);
 
                 // Generate bar chart.
                 const instance = rbmViz.default.barChart(
                     el,
                     input.dfResults,
-                    input.lMetric,
+                    {...input.lMetric, y: input.strOutcome}, // specify outcome to be plotted on the y-axis
                     input.vThreshold,
                     input.dfGroups
                 );

--- a/inst/htmlwidgets/Widget_BarChart.yaml
+++ b/inst/htmlwidgets/Widget_BarChart.yaml
@@ -3,6 +3,10 @@ dependencies:
     version: 1.2.0
     src: 'rbm-viz-1.2.0'
     script: 'rbm-viz.js'
+  - name: clickCallback
+    version: 0.0.1
+    src: 'utils-0.0.1'
+    script: 'clickCallback.js'
   - name: addWidgetControls
     version: 0.0.1
     src: 'utils-0.0.1'

--- a/inst/htmlwidgets/Widget_ScatterPlot.js
+++ b/inst/htmlwidgets/Widget_ScatterPlot.js
@@ -10,35 +10,8 @@ HTMLWidgets.widget({
                 // Assign a unique ID to the element.
                 el.id = `scatterPlot--${input.lMetric.MetricID}`;
 
-                // Add click event listener to chart.
-                if (input.bAddGroupSelect)
-                    input.lMetric.clickCallback = function(d) {
-                        instance.data.config.selectedGroupIDs = instance.data.config.selectedGroupIDs.includes(d.GroupID)
-                            ? 'None'
-                            : d.GroupID;
-
-                        // Update group select.
-                        groupSelect.value = instance.data.config.selectedGroupIDs;
-
-                        // Set country select to 'None' if a group ID is selected.
-                        if (countrySelect)
-                            countrySelect.value = "None";
-
-                        instance.helpers.updateConfig(
-                            instance,
-                            instance.data.config
-                        );
-
-                    // Update Shiny input if in Shiny environment.
-                    if (typeof Shiny !== 'undefined') {
-                          if (instance.data.config.selectedGroupIDs.length > 0) {
-                            Shiny.setInputValue(
-                              'site',
-                              instance.data.config.selectedGroupIDs
-                            )
-                        }
-                    }
-                  };
+                // Add click event callback to chart.
+                input.lMetric.clickCallback = clickCallback(el, input);
 
                 // Generate scatter plot.
                 const instance = rbmViz.default.scatterPlot(

--- a/inst/htmlwidgets/Widget_ScatterPlot.yaml
+++ b/inst/htmlwidgets/Widget_ScatterPlot.yaml
@@ -3,6 +3,10 @@ dependencies:
     version: 1.2.0
     src: 'rbm-viz-1.2.0'
     script: 'rbm-viz.js'
+  - name: clickCallback
+    version: 0.0.1
+    src: 'utils-0.0.1'
+    script: 'clickCallback.js'
   - name: addWidgetControls
     version: 0.0.1
     src: 'utils-0.0.1'

--- a/inst/htmlwidgets/Widget_TimeSeries.js
+++ b/inst/htmlwidgets/Widget_TimeSeries.js
@@ -10,40 +10,14 @@ HTMLWidgets.widget({
                 // Assign a unique ID to the element.
                 el.id = `timeSeries--${input.lMetric.MetricID}_${input.strOutcome}`;
 
-                // Update y-axis variable.
-                input.lMetric.y = input.strOutcome;
-
                 // Add click event listener to chart.
-                if (input.bAddGroupSelect)
-                    input.lMetric.clickCallback = function(d) {
-                        instance.data.config.selectedGroupIDs = instance.data.config.selectedGroupIDs.includes(d.GroupID)
-                            ? 'None'
-                            : d.GroupID;
-
-                        groupSelect.value = instance.data.config.selectedGroupIDs;
-
-                        if (instance.data.config.selectedGroupIDs === 'None')
-                            delete instance.data.config.selectedGroupIDs;
-                        instance.helpers.updateSelectedGroupIDs(
-                            instance.data.config.selectedGroupIDs
-                        );
-
-                        // Update Shiny input if in Shiny environment.
-                        if (typeof Shiny !== 'undefined') {
-                          if (instance.data.config.selectedGroupIDs.length > 0) {
-                            Shiny.setInputValue(
-                              'site',
-                              instance.data.config.selectedGroupIDs
-                            )
-                          }
-                        }
-                  };
+                input.lMetric.clickCallback = clickCallback(el, input);
 
                 // Generate time series.
                 const instance = rbmViz.default.timeSeries(
                     el,
                     input.dfResults,
-                    input.lMetric,
+                    {...input.lMetric, y: input.strOutcome}, // specify outcome to be plotted on the y-axis
                     input.vThreshold,
                     null, // confidence intervals parameter
                     input.dfGroups
@@ -57,8 +31,6 @@ HTMLWidgets.widget({
                     input.dfGroups,
                     input.bAddGroupSelect
                 );
-                if (countrySelect)
-                    countrySelect.parentElement.style.display = 'none'; // hide country select
             },
             resize: function(width, height) {
             }

--- a/inst/htmlwidgets/Widget_TimeSeries.yaml
+++ b/inst/htmlwidgets/Widget_TimeSeries.yaml
@@ -3,6 +3,10 @@ dependencies:
     version: 1.2.0
     src: 'rbm-viz-1.2.0'
     script: 'rbm-viz.js'
+  - name: clickCallback
+    version: 0.0.1
+    src: 'utils-0.0.1'
+    script: 'clickCallback.js'
   - name: addWidgetControls
     version: 0.0.1
     src: 'utils-0.0.1'

--- a/inst/utils-0.0.1/clickCallback.js
+++ b/inst/utils-0.0.1/clickCallback.js
@@ -1,12 +1,46 @@
-const clickCallback = function(d, siteSelect, instance) {
-    // update chart config
-    instance.data.config.selectedGroupIDs = instance.data.config.selectedGroupIDs.includes(d.groupid)
-        ? 'None'
-        : d.groupid;
+const clickCallback = function(el, input) {
+    return function(d) {
+        // Get chart instance, attached to canvas element.
+        const instance = el.querySelector('canvas').chart;
 
-    // update dropdown
-    siteSelect.value = instance.data.config.selectedGroupIDs;
+        instance.data.config.selectedGroupIDs = instance.data.config.selectedGroupIDs.includes(d.GroupID)
+            ? 'None'
+            : d.GroupID;
 
-    // update chart
-    instance.helpers.updateConfig(instance, instance.data.config);
+        // Update group select.
+        const groupSelect = el.querySelector('.gsm-widget-control--group');
+        if (groupSelect !== null)
+            groupSelect.value = instance.data.config.selectedGroupIDs;
+
+        // Set country select to 'None' if a group ID is selected.
+        const countrySelect = el.querySelector('.gsm-widget-control--country');
+        if (countrySelect !== null)
+            countrySelect.value = "None";
+
+        // Update barChart and scatterPlot.
+        if (Object.keys(instance.helpers).includes('updateConfig')) {
+            instance.helpers.updateConfig(
+                instance,
+                instance.data.config
+            );
+        }
+        // Update timeSeries.
+        else if (Object.keys(instance.helpers).includes('updateSelectedGroupIDs')) {
+            if (instance.data.config.selectedGroupIDs === 'None')
+                delete instance.data.config.selectedGroupIDs;
+            instance.helpers.updateSelectedGroupIDs(
+                instance.data.config.selectedGroupIDs
+            );
+        }
+
+        // Update Shiny input if in Shiny environment.
+        if (typeof Shiny !== 'undefined') {
+            if (instance.data.config.selectedGroupIDs.length > 0) {
+                Shiny.setInputValue(
+                    input.strShinyGroupSelectID,
+                    instance.data.config.selectedGroupIDs
+                )
+            }
+        }
+    };
 };


### PR DESCRIPTION
## Overview
- Resolves #1749 
- Resolves #1752 

## Test Notes/Sample Code
This update should attach a click callback to the bar chart, scatter plot, and time series irrespective of whether the group and country selects are enabled. The click callback should update the group and country selects in the widget, if enabled, as well as the Shiny input associated with the value of `strShinyGroupSelectID`, which defaults to `"GroupID"`.

```
load_all()
# Run reports
lCharts <- MakeCharts(
  dfResults = reportingResults,
  dfGroups = reportingGroups,
  dfMetrics = reportingMetrics,
  dfBounds = reportingBounds
)

strOutpath <- "StandardSiteReport.html"
Report_KRI(
  lCharts = lCharts,
  dfResults = reportingResults,
  dfGroups = reportingGroups,
  dfMetrics = reportingMetrics,
  strOutpath = strOutpath
)
```

Notes: 
