### PR TITLE
fixup: add dplyr filter namespace

### DIFF
--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -102,7 +102,7 @@ Report_OverviewText(
 ```{r, echo=FALSE, results='asis'}
 
 for (i in unique(params$dfMetrics$MetricID)) {
-  lMetric <- params$dfMetrics %>% filter(MetricID == i) %>% as.list
+  lMetric <- params$dfMetrics %>% dplyr::filter(MetricID == i) %>% as.list
 
   print(htmltools::h3(lMetric$Metric))
   


### PR DESCRIPTION
Otherwise the report errors with Object MetricID not found, when run in a more isolated context where dplyr has not already been loaded already
