### PR TITLE
Fix summary tables in reports and add `metricTable` to `Visualize_Metric()` output

### DIFF
--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -19,7 +19,7 @@
 Report_MetricTable <- function(
   dfResults,
   dfGroups,
-  strGroupLevel = c("Site", "Study", "Country"),
+  strGroupLevel = c("Site", "Country", "Study"),
   strGroupDetailsParams = NULL
 ) {
   dfResults <- dfResults %>%
@@ -38,7 +38,7 @@ Report_MetricTable <- function(
     stop("Expecting `dfResults` to be filtered to one unique MetricID, but many detected.")
   }
 
-  if (strGroupLevel == 'Site') {
+  if (rlang::arg_match(strGroupLevel) == 'Site') {
     dfResults$Group = glue::glue('{dfResults$GroupID} ({dfResults$InvestigatorLastName})')
   } else {
     dfResults$Group = dfResults$GroupID

--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -8,6 +8,8 @@
 #' data based on certain conditions and displays the result in a datatable.
 #'
 #' @inheritParams shared-params
+#' @param dfResults `r gloss_param("dfResults")`
+#'   `r gloss_extra("dfResults_filtered")`
 #' @param strSnapshotDate user specified snapshot date as string
 #' @param strGroupLevel  group level for the table
 #' @param strGroupDetailsParams one or more parameters from dfGroups to be added as columns in the table
@@ -27,6 +29,10 @@ Report_MetricTable <- function(dfResults,
 
   if (!nrow(dfResults)) {
     return("Nothing flagged for this KRI.")
+  }
+
+  if (length(unique(dfResults$MetricID)) > 1) {
+    stop("Expecting `dfResults` to be filtered to one unique MetricID, but many detected.")
   }
 
   SummaryTable <- dfResults %>%

--- a/R/Visualize_Metric.R
+++ b/R/Visualize_Metric.R
@@ -20,6 +20,7 @@
 #' - timeSeriesContinuousScoreJS: A time series chart using JavaScript with score on the y-axis.
 #' - timeSeriesContinuousMetricJS: A time series chart using JavaScript with metric on the y-axis.
 #' - timeSeriesContinuousNumeratorJS: A time series chart using JavaScript with numerator on the y-axis.
+#' - metricTable: A table containing all
 #'
 #'
 #' @examples
@@ -129,6 +130,13 @@ Visualize_Metric <- function(
       dfResults = dfResults_current,
       strType = "Score",
       vThreshold = vThreshold
+    )
+
+    lCharts$metricTable <- Report_MetricTable(
+      dfResults = dfResults_current,
+      dfGroups = dfGroups,
+      strGroupLevel = lMetric$GroupLevel,
+      strSnapshotDate = strSnapshotDate
     )
   }
   # Continuous Charts -------------------------------------------------------

--- a/R/Visualize_Metric.R
+++ b/R/Visualize_Metric.R
@@ -135,8 +135,7 @@ Visualize_Metric <- function(
     lCharts$metricTable <- Report_MetricTable(
       dfResults = dfResults_current,
       dfGroups = dfGroups,
-      strGroupLevel = lMetric$GroupLevel,
-      strSnapshotDate = strSnapshotDate
+      strGroupLevel = lMetric$GroupLevel
     )
   }
   # Continuous Charts -------------------------------------------------------

--- a/R/util-Report.R
+++ b/R/util-Report.R
@@ -25,10 +25,12 @@ filter_by_latest_SnapshotDate <- function(dfResults, strSnapshotDate = NULL) {
   return(dplyr::filter(dfResults, .data$SnapshotDate == strSnapshotDate))
 }
 
-add_Groups_metadata <- function(dfResults,
+add_Groups_metadata <- function(
+  dfResults,
   dfGroups,
   strGroupLevel = c("Site", "Study", "Country"),
-  strGroupDetailsParams) {
+  strGroupDetailsParams
+) {
   if (nrow(dfResults)) {
     strGroupLevel <- rlang::arg_match(strGroupLevel)
     dfGroups_wide <- widen_dfGroups(dfGroups, strGroupLevel, strGroupDetailsParams)

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -111,12 +111,7 @@ for (i in unique(params$dfMetrics$MetricID)) {
     strMetricID = lMetric$MetricID
   )
 
- Report_MetricTable(
-    params$dfResults, 
-    params$dfGroups, 
-    strSnapshotDate = setup$SnapshotDate, 
-    strGroupLevel = setup$GroupLevel
-) %>%
+ params$lCharts[[lMetric$MetricID]]$metricTable %>%
    cat
 
 }

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -116,7 +116,8 @@ for (i in unique(params$dfMetrics$MetricID)) {
     params$dfGroups, 
     strSnapshotDate = setup$SnapshotDate, 
     strGroupLevel = setup$GroupLevel
-)
+) %>%
+   cat
 
 }
 

--- a/man/Report_MetricTable.Rd
+++ b/man/Report_MetricTable.Rd
@@ -7,7 +7,6 @@
 Report_MetricTable(
   dfResults,
   dfGroups,
-  strSnapshotDate = NULL,
   strGroupLevel = c("Site", "Study", "Country"),
   strGroupDetailsParams = NULL
 )
@@ -17,8 +16,6 @@ Report_MetricTable(
 For this function, \code{dfResults} must be filtered to a single KRI (\code{MetricID}).}
 
 \item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
-
-\item{strSnapshotDate}{user specified snapshot date as string}
 
 \item{strGroupLevel}{group level for the table}
 

--- a/man/Report_MetricTable.Rd
+++ b/man/Report_MetricTable.Rd
@@ -7,7 +7,7 @@
 Report_MetricTable(
   dfResults,
   dfGroups,
-  strGroupLevel = c("Site", "Study", "Country"),
+  strGroupLevel = c("Site", "Country", "Study"),
   strGroupDetailsParams = NULL
 )
 }

--- a/man/Report_MetricTable.Rd
+++ b/man/Report_MetricTable.Rd
@@ -13,7 +13,8 @@ Report_MetricTable(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.
+For this function, \code{dfResults} must be filtered to a single KRI (\code{MetricID}).}
 
 \item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 

--- a/man/Visualize_Metric.Rd
+++ b/man/Visualize_Metric.Rd
@@ -41,6 +41,7 @@ A list containing the following charts:
 \item timeSeriesContinuousScoreJS: A time series chart using JavaScript with score on the y-axis.
 \item timeSeriesContinuousMetricJS: A time series chart using JavaScript with metric on the y-axis.
 \item timeSeriesContinuousNumeratorJS: A time series chart using JavaScript with numerator on the y-axis.
+\item metricTable: A table containing all
 }
 }
 \description{

--- a/man/glossary/dfResults_filtered.Rmd
+++ b/man/glossary/dfResults_filtered.Rmd
@@ -1,0 +1,1 @@
+For this function, `dfResults` must be filtered to a single KRI (`MetricID`).

--- a/tests/testthat/test-Report_MetricTable.R
+++ b/tests/testthat/test-Report_MetricTable.R
@@ -5,7 +5,9 @@ test_that("Empty data frames return default message", {
 })
 
 test_that("Correct data structure when proper dataframe is passed", {
-  result <- Report_MetricTable(reportingResults, reportingGroups)
+  reportingResults_filt <- reportingResults %>%
+    dplyr::filter(MetricID == unique(reportingResults$MetricID)[1])
+  result <- Report_MetricTable(reportingResults_filt, reportingGroups)
   expect_s3_class(result, "kableExtra")
   expect_true(grepl("<table", result))
   expect_true(grepl("162", result))
@@ -15,12 +17,20 @@ test_that("Correct data structure when proper dataframe is passed", {
 })
 
 test_that("Flag filtering works correctly", {
-  result <- Report_MetricTable(reportingResults, reportingGroups)
+  reportingResults_filt <- reportingResults %>%
+    dplyr::filter(MetricID == unique(reportingResults$MetricID)[1])
+  result <- Report_MetricTable(reportingResults_filt, reportingGroups)
   expect_s3_class(result, "kableExtra")
   expect_false(grepl("Nkaujiaong", result))
 })
 
 test_that("Score rounding works correctly", {
-  result <- Report_MetricTable(reportingResults, reportingGroups)
-  expect_true(grepl("2.292", result))
+  reportingResults_filt <- reportingResults %>%
+    dplyr::filter(MetricID == unique(reportingResults$MetricID)[1])
+  result <- Report_MetricTable(reportingResults_filt, reportingGroups)
+  expect_true(grepl("0.048", result))
+})
+
+test_that("Errors out when multiple MetricIDs passed in", {
+  expect_error(Report_MetricTable(reportingResults, reportingGroups))
 })

--- a/tests/testthat/test-Report_MetricTable.R
+++ b/tests/testthat/test-Report_MetricTable.R
@@ -12,8 +12,6 @@ test_that("Correct data structure when proper dataframe is passed", {
   expect_true(grepl("<table", result))
   expect_true(grepl("162", result))
   expect_true(grepl("Kimler", result))
-  expect_true(grepl("US", result))
-  expect_true(grepl("Japan", result))
 })
 
 test_that("Flag filtering works correctly", {
@@ -28,7 +26,7 @@ test_that("Score rounding works correctly", {
   reportingResults_filt <- reportingResults %>%
     dplyr::filter(MetricID == unique(reportingResults$MetricID)[1])
   result <- Report_MetricTable(reportingResults_filt, reportingGroups)
-  expect_true(grepl("0.048", result))
+  expect_true(grepl("0.05", result))
 })
 
 test_that("Errors out when multiple MetricIDs passed in", {

--- a/tests/testthat/test-Visualize_Metric.R
+++ b/tests/testthat/test-Visualize_Metric.R
@@ -15,6 +15,7 @@ test_that("Visualize_Metric processes data correctly", {
   expect_true("timeSeriesContinuousScoreJS" %in% names(charts))
   expect_true("timeSeriesContinuousMetricJS" %in% names(charts))
   expect_true("timeSeriesContinuousNumeratorJS" %in% names(charts))
+  expect_true("metricTable" %in% names(charts))
 })
 
 test_that("Visualize_Metric handles missing MetricID", {

--- a/vignettes/DataReporting.Rmd
+++ b/vignettes/DataReporting.Rmd
@@ -389,14 +389,18 @@ snapshot <- RunWorkflows(ss_wf, lData, bKeepInputData = TRUE)
 
 -   `Visualize_Scatter()`: Creates scatter plot of Total Exposure (in days, on log scale) vs Total Number of Event(s) of Interest (on linear scale). Each data point represents one site. Outliers are plotted in red with the site label attached. This plot is only created when statistical method is **not** defined as `identity`. Chart is called `scatter` in the `lCharts` object.
 -   `Visualize_Score()`: Provides a standard visualization for Score or KRI. Charts are called `barScore` or `barMetric` in the `lCharts` object.
--   `Visualize_Metric()`: Creates all available charts for a metric using the data provided.
+-   `Visualize_Metric()`: Creates all available charts and tables for a metric using the data provided.
 
 
 ### Widget Functions
 
-- `Widget_GroupOverview`: Creates an interactive table displaying the flag distribution for all groups across all metrics.
-- `Widget_BarChart`:  Creates an interactive bar chart visualization for Score or KRI. Charts are called `barScoreJS` or `barMetricJS` in the `lCharts` object.
-- `Widget_ScatterPlot`: Creates an interactive scatter plot of Total Exposure (in days, on log scale) vs Total Number of Event(s) of Interest (on linear scale). Each data point represents one site. Outliers are plotted in red with the site label attached.Chart is called `scatterJS` in the `lCharts` object.
-- `Widget_TimeSeries`: Creates an interactive time series scatter plot of the score, metric or numerator. Charts are called `timeSeriesContinuousScoreJS`, `timeSeriesContinuousMetricJS`, or `timeSeriesContinuousNumeratorJS` in the `lCharts` object.
+- `Widget_GroupOverview()`: Creates an interactive table displaying the flag distribution for all groups across all metrics.
+- `Widget_BarChart()`:  Creates an interactive bar chart visualization for Score or KRI. Charts are called `barScoreJS` or `barMetricJS` in the `lCharts` object.
+- `Widget_ScatterPlot()`: Creates an interactive scatter plot of Total Exposure (in days, on log scale) vs Total Number of Event(s) of Interest (on linear scale). Each data point represents one site. Outliers are plotted in red with the site label attached.Chart is called `scatterJS` in the `lCharts` object.
+- `Widget_TimeSeries()`: Creates an interactive time series scatter plot of the score, metric or numerator. Charts are called `timeSeriesContinuousScoreJS`, `timeSeriesContinuousMetricJS`, or `timeSeriesContinuousNumeratorJS` in the `lCharts` object.
+
+### Table Functions
+
+- `Report_MetricTable()`: Creates a sortable table displaying the flags per group (e.g. Site, Country) for one metric at a time.
 
                                                                                                                                                                                        


### PR DESCRIPTION
## Overview
Resolves the bug in #1765 that tables were not rendering in report output.

Also adds the output of `Report_MetricTable()` to the `MakeCharts()`/`Visualize_Metric()` output as `metricTable` for easier reference in report generation.  

Updated relevant documentation to note the addition of `metricTable` to `lCharts` list.

closes #1765

## Test Notes/Sample Code
```
# Run reports
lCharts <- MakeCharts(
  dfResults = reportingResults,
  dfGroups = reportingGroups,
  dfMetrics = reportingMetrics,
  dfBounds = reportingBounds
)

## check to see that `metricTable` is in lCharts output
lCharts$kri0001$metricTable

strOutpath <- "StandardSiteReport.html"
Report_KRI(
  lCharts = lCharts,
  dfResults = reportingResults,
  dfGroups = reportingGroups,
  dfMetrics = reportingMetrics,
  strOutpath = strOutpath
)
```

Notes: 

