### PR TITLE
Use `required` param from `spec` in `CheckSpec()`

### DIFF
--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -50,11 +50,11 @@ CheckSpec <- function(lData, lSpec) {
     cli_alert("All {length(lSpecDataFrames)} data.frame(s) in the spec are present in the data: {lSpecDataFrames}")
   }
 
-  # Check that all columns in the spec are present in the data
+  # Check that all required columns in the spec are present in the data
   allCols <- c()
   missingCols <- c()
   for (strDataFrame in lSpecDataFrames) {
-    lSpecColumns <- names(lSpec[[strDataFrame]])
+    lSpecColumns <- which(sapply(lSpec[[strDataFrame]], function(x) x$required)) %>% names
     lDataColumns <- names(lData[[strDataFrame]])
     allCols <- c(allCols, paste(strDataFrame, lSpecColumns, sep = "$"))
 

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -64,8 +64,8 @@ CheckSpec <- function(lData, lSpec) {
     }
   }
   if (length(missingCols) > 0) {
-    cli_alert_danger("Not all columns in the spec are present in the data, missing columns are: {missingCols}")
+    cli_alert_danger("Not all required columns in the spec are present in the data, missing columns are: {missingCols}")
   } else {
-    cli_alert("All {length(allCols)} columns in the spec are present in the data: {allCols}")
+    cli_alert("All {length(allCols)} required columns in the spec are present in the data: {allCols}")
   }
 }

--- a/inst/workflow/metrics/kri0001.yaml
+++ b/inst/workflow/metrics/kri0001.yaml
@@ -13,11 +13,15 @@ meta:
   nMinDenominator: 30
 spec:
   Mapped_AE:
-    subjid: required
+    subjid:
+      required: true
   Mapped_Enrolled:
-    subjid: required
-    invid: required
-    timeonstudy: required
+    subjid:
+      required: true
+    invid:
+      required: true
+    timeonstudy:
+      required: true
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0002.yaml
+++ b/inst/workflow/metrics/kri0002.yaml
@@ -13,11 +13,15 @@ meta:
   nMinDenominator: 30
 spec:
   Mapped_SeriousAE:
-    - subjid
+    subjid:
+      required: true
   Mapped_Enrolled:
-    - subjid
-    - invid
-    - timeonstudy
+    subjid:
+      required: true
+    invid:
+      required: true
+    timeonstudy:
+      required: true
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/tests/testthat/test-util-checkSpec.R
+++ b/tests/testthat/test-util-checkSpec.R
@@ -58,3 +58,35 @@ test_that("Multiple missing columns are correctly reported", {
     regexp = "missing columns are: df1\\$b and df2\\$y"
   )
 })
+
+test_that("Missing column only gets a flag when it is required", {
+  lData <- list(reporting_groups = gsm::reportingGroups)
+  lSpec <- list(
+    reporting_groups = list(
+      GroupID = list(required = TRUE),
+      GroupLevel = list(required = TRUE),
+      Param = list(required = TRUE),
+      Value = list(required = TRUE),
+      NewVar = list(required = FALSE)
+    )
+  )
+  expect_message(
+    CheckSpec(lData, lSpec),
+    regexp = "All 4 required columns"
+  )
+
+  lSpec <- list(
+    reporting_groups = list(
+      GroupID = list(required = TRUE),
+      GroupLevel = list(required = TRUE),
+      Param = list(required = TRUE),
+      Value = list(required = TRUE),
+      NewVar = list(required = TRUE)
+    )
+  )
+  expect_message(
+    CheckSpec(lData, lSpec),
+    regexp = "Not all required columns"
+  )
+
+})


### PR DESCRIPTION
## Overview
closes #1777

## Test Notes/Sample Code
```
lData <- list(reporting_groups = gsm::reportingGroups)
lSpec <- list(
   reporting_groups = list(
     GroupID = list(required = TRUE),
     GroupLevel = list(required = TRUE),
     Param = list(required = TRUE),
     Value = list(required = TRUE),
     NewVar = list(required = FALSE)
   )
)
CheckSpec(lData, lSpec) # Prints message that everything is found

lSpec <- list(
   reporting_groups = list(
     GroupID = list(required = TRUE),
     GroupLevel = list(required = TRUE),
     Param = list(required = TRUE),
     Value = list(required = TRUE),
     NewVar = list(required = TRUE)
   )
)
CheckSpec(lData, lSpec) # Returns error that NewVar is not found
```

Notes: 

