### PR TITLE
Add `type` field and query columns to all `spec`s

### DIFF
--- a/inst/workflow/metrics/cou0001.yaml
+++ b/inst/workflow/metrics/cou0001.yaml
@@ -11,17 +11,21 @@ meta:
   Score: Adjusted Z-Score
   Threshold: -2,-1,2,3
   nMinDenominator: 30
-mapping_spec: 
+spec:
   Mapped_AE:
     subjid:
       required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0002.yaml
+++ b/inst/workflow/metrics/cou0002.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_AE:
     subjid:
       required: true
+      type: character
+    aeser:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0003.yaml
+++ b/inst/workflow/metrics/cou0003.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_PD:
     subjid:
       required: true
+      type: character
+    deemedimportant:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0004.yaml
+++ b/inst/workflow/metrics/cou0004.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_PD:
     subjid:
       required: true
+      type: character
+    deemedimportant:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0005.yaml
+++ b/inst/workflow/metrics/cou0005.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_LB:
     subjid:
       required: true
+      type: character
+    toxgrg_nsv:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0006.yaml
+++ b/inst/workflow/metrics/cou0006.yaml
@@ -15,13 +15,17 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_STUDCOMP:
     subjid:
       required: true
+      type: character
     compyn:
       required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0007.yaml
+++ b/inst/workflow/metrics/cou0007.yaml
@@ -15,11 +15,20 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_SDRGCOMP:
     subjID:
       required: true
+      type: character
+    sdrgyn:
+      required: true
+      type: character
+    phase:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0008.yaml
+++ b/inst/workflow/metrics/cou0008.yaml
@@ -15,24 +15,36 @@ spec:
   Mapped_QUERY:
     subject_nsv:
       required: true
+      type: character
+    querystatus:
+      required: true
+      type: character
   Mapped_ENROLL:
     subject_nsv:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_DATACHG:
     subject_nsv:
       required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold
     params:
       strThreshold: Threshold
+  - name: RunQuery
+    output: Temp_QUERY
+    params:
+      df: Mapped_QUERY
+      strQuery: "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
   - name: Input_Rate
     output: Analysis_Input
     params:
       dfSubjects: Mapped_ENROLL
-      dfNumerator: Mapped_QUERY
+      dfNumerator: Temp_QUERY
       dfDenominator: Mapped_DATACHG
       strSubjectCol: subject_nsv
       strGroupCol: country

--- a/inst/workflow/metrics/cou0009.yaml
+++ b/inst/workflow/metrics/cou0009.yaml
@@ -15,11 +15,20 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_QUERY:
     subject_nsv:
       required: true
+      type: character
+    querystatus:
+      required: true
+      type: character
+    queryage:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0010.yaml
+++ b/inst/workflow/metrics/cou0010.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_DATAENT:
     subject_nsv:
       required: true
+      type: character
+    data_entry_lag:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0011.yaml
+++ b/inst/workflow/metrics/cou0011.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
+      type: character
     country:
       required: true
+      type: character
   Mapped_DATAENT:
     subject_nsv:
       required: true
+      type: character
+    n_changes:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/cou0012.yaml
+++ b/inst/workflow/metrics/cou0012.yaml
@@ -13,10 +13,15 @@ meta:
   nMinDenominator: 3
 spec:
   Mapped_SCREEN:
-    subjectid:
+    subjid:
       required: true
+      type: character
     country:
       required: true
+      type: character
+    enrollyn:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0001.yaml
+++ b/inst/workflow/metrics/kri0001.yaml
@@ -20,7 +20,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
     timeonstudy:

--- a/inst/workflow/metrics/kri0001.yaml
+++ b/inst/workflow/metrics/kri0001.yaml
@@ -15,13 +15,17 @@ spec:
   Mapped_AE:
     subjid:
       required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0002.yaml
+++ b/inst/workflow/metrics/kri0002.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_AE:
     subjid:
       required: true
+      type: character
+    aeser:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
+      type: character
     invid:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0003.yaml
+++ b/inst/workflow/metrics/kri0003.yaml
@@ -23,7 +23,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
     timeonstudy:

--- a/inst/workflow/metrics/kri0003.yaml
+++ b/inst/workflow/metrics/kri0003.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_PD:
     subjid:
       required: true
+      type: character
+    deemedimportant:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0004.yaml
+++ b/inst/workflow/metrics/kri0004.yaml
@@ -23,7 +23,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
     timeonstudy:

--- a/inst/workflow/metrics/kri0004.yaml
+++ b/inst/workflow/metrics/kri0004.yaml
@@ -15,13 +15,20 @@ spec:
   Mapped_PD:
     subjid:
       required: true
+      type: character
+    deemedimportant:
+      required: true
+      type: character
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
     timeonstudy:
       required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0005.yaml
+++ b/inst/workflow/metrics/kri0005.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_LB:
     subjid:
       required: true
+      type: character
+    toxgrg_nsv:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0005.yaml
+++ b/inst/workflow/metrics/kri0005.yaml
@@ -16,7 +16,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_LB:

--- a/inst/workflow/metrics/kri0006.yaml
+++ b/inst/workflow/metrics/kri0006.yaml
@@ -15,13 +15,17 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_STUDCOMP:
     subjid:
       required: true
+      type: character
     compyn:
       required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0006.yaml
+++ b/inst/workflow/metrics/kri0006.yaml
@@ -16,7 +16,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_STUDCOMP:

--- a/inst/workflow/metrics/kri0007.yaml
+++ b/inst/workflow/metrics/kri0007.yaml
@@ -16,7 +16,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_SDRGCOMP:

--- a/inst/workflow/metrics/kri0007.yaml
+++ b/inst/workflow/metrics/kri0007.yaml
@@ -15,11 +15,20 @@ spec:
   Mapped_ENROLL:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_SDRGCOMP:
-    subjid:
+    subjID:
       required: true
+      type: character
+    sdrgyn:
+      required: true
+      type: character
+    phase:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0008.yaml
+++ b/inst/workflow/metrics/kri0008.yaml
@@ -15,14 +15,21 @@ spec:
   Mapped_QUERY:
     subject_nsv:
       required: true
+      type: character
+    querystatus:
+      required: true
+      type: character
   Mapped_ENROLL:
     subject_nsv:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_DATACHG:
     subject_nsv:
       required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0008.yaml
+++ b/inst/workflow/metrics/kri0008.yaml
@@ -23,7 +23,7 @@ spec:
     subject_nsv:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_DATACHG:

--- a/inst/workflow/metrics/kri0009.yaml
+++ b/inst/workflow/metrics/kri0009.yaml
@@ -15,11 +15,20 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_QUERY:
     subject_nsv:
       required: true
+      type: character
+    querystatus:
+      required: true
+      type: character
+    queryage:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0009.yaml
+++ b/inst/workflow/metrics/kri0009.yaml
@@ -16,7 +16,7 @@ spec:
     subject_nsv:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_QUERY:

--- a/inst/workflow/metrics/kri0010.yaml
+++ b/inst/workflow/metrics/kri0010.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
   Mapped_DATAENT:
     subject_nsv:
       required: true
+      type: character
+    data_entry_lag:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0010.yaml
+++ b/inst/workflow/metrics/kri0010.yaml
@@ -16,7 +16,7 @@ spec:
     subject_nsv:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
   Mapped_DATAENT:

--- a/inst/workflow/metrics/kri0011.yaml
+++ b/inst/workflow/metrics/kri0011.yaml
@@ -15,11 +15,17 @@ spec:
   Mapped_ENROLL:
     subject_nsv:
       required: true
+      type: character
     invid:
       required: true
+      type: character
   Mapped_DATACHG:
     subject_nsv:
       required: true
+      type: character
+    n_changes:
+      required: true
+      type: numeric
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0012.yaml
+++ b/inst/workflow/metrics/kri0012.yaml
@@ -15,8 +15,13 @@ spec:
   Mapped_SCREEN:
     subjid:
       required: true
-    invid:
+      type: character
+    country:
       required: true
+      type: character
+    enrollyn:
+      required: true
+      type: character
 steps:
   - name: ParseThreshold
     output: vThreshold

--- a/inst/workflow/metrics/kri0012.yaml
+++ b/inst/workflow/metrics/kri0012.yaml
@@ -16,7 +16,7 @@ spec:
     subjid:
       required: true
       type: character
-    country:
+    invid:
       required: true
       type: character
     enrollyn:

--- a/tests/testthat/_snaps/util-MakeWorkflowList.md
+++ b/tests/testthat/_snaps/util-MakeWorkflowList.md
@@ -10,7 +10,7 @@
       [1] "meta"  "spec"  "steps" "path"  "name" 
       
       $cou0001
-      [1] "meta"         "mapping_spec" "steps"        "path"         "name"        
+      [1] "meta"  "spec"  "steps" "path"  "name" 
       
       $cou0002
       [1] "meta"  "spec"  "steps" "path"  "name" 
@@ -1406,95 +1406,111 @@
       
       $cou0008[[2]]
       $cou0008[[2]]$name
-      [1] "Input_Rate"
+      [1] "RunQuery"
       
       $cou0008[[2]]$output
-      [1] "Analysis_Input"
+      [1] "Temp_QUERY"
       
       $cou0008[[2]]$params
-      $cou0008[[2]]$params$dfSubjects
-      [1] "Mapped_ENROLL"
-      
-      $cou0008[[2]]$params$dfNumerator
+      $cou0008[[2]]$params$df
       [1] "Mapped_QUERY"
       
-      $cou0008[[2]]$params$dfDenominator
-      [1] "Mapped_DATACHG"
-      
-      $cou0008[[2]]$params$strSubjectCol
-      [1] "subject_nsv"
-      
-      $cou0008[[2]]$params$strGroupCol
-      [1] "country"
-      
-      $cou0008[[2]]$params$strGroupLevel
-      [1] "GroupLevel"
-      
-      $cou0008[[2]]$params$strNumeratorMethod
-      [1] "Count"
-      
-      $cou0008[[2]]$params$strDenominatorMethod
-      [1] "Count"
+      $cou0008[[2]]$params$strQuery
+      [1] "SELECT * FROM df WHERE querystatus IN ('Open','Answered','Closed')"
       
       
       
       $cou0008[[3]]
       $cou0008[[3]]$name
-      [1] "Transform_Rate"
+      [1] "Input_Rate"
       
       $cou0008[[3]]$output
-      [1] "Analysis_Transformed"
+      [1] "Analysis_Input"
       
       $cou0008[[3]]$params
-      $cou0008[[3]]$params$dfInput
-      [1] "Analysis_Input"
+      $cou0008[[3]]$params$dfSubjects
+      [1] "Mapped_ENROLL"
+      
+      $cou0008[[3]]$params$dfNumerator
+      [1] "Temp_QUERY"
+      
+      $cou0008[[3]]$params$dfDenominator
+      [1] "Mapped_DATACHG"
+      
+      $cou0008[[3]]$params$strSubjectCol
+      [1] "subject_nsv"
+      
+      $cou0008[[3]]$params$strGroupCol
+      [1] "country"
+      
+      $cou0008[[3]]$params$strGroupLevel
+      [1] "GroupLevel"
+      
+      $cou0008[[3]]$params$strNumeratorMethod
+      [1] "Count"
+      
+      $cou0008[[3]]$params$strDenominatorMethod
+      [1] "Count"
       
       
       
       $cou0008[[4]]
       $cou0008[[4]]$name
-      [1] "Analyze_NormalApprox"
+      [1] "Transform_Rate"
       
       $cou0008[[4]]$output
-      [1] "Analysis_Analyzed"
-      
-      $cou0008[[4]]$params
-      $cou0008[[4]]$params$dfTransformed
       [1] "Analysis_Transformed"
       
-      $cou0008[[4]]$params$strType
-      [1] "Type"
+      $cou0008[[4]]$params
+      $cou0008[[4]]$params$dfInput
+      [1] "Analysis_Input"
       
       
       
       $cou0008[[5]]
       $cou0008[[5]]$name
-      [1] "Flag_NormalApprox"
+      [1] "Analyze_NormalApprox"
       
       $cou0008[[5]]$output
-      [1] "Analysis_Flagged"
-      
-      $cou0008[[5]]$params
-      $cou0008[[5]]$params$dfAnalyzed
       [1] "Analysis_Analyzed"
       
-      $cou0008[[5]]$params$vThreshold
-      [1] "vThreshold"
+      $cou0008[[5]]$params
+      $cou0008[[5]]$params$dfTransformed
+      [1] "Analysis_Transformed"
+      
+      $cou0008[[5]]$params$strType
+      [1] "Type"
       
       
       
       $cou0008[[6]]
       $cou0008[[6]]$name
-      [1] "Summarize"
+      [1] "Flag_NormalApprox"
       
       $cou0008[[6]]$output
-      [1] "Analysis_Summary"
-      
-      $cou0008[[6]]$params
-      $cou0008[[6]]$params$dfFlagged
       [1] "Analysis_Flagged"
       
-      $cou0008[[6]]$params$nMinDenominator
+      $cou0008[[6]]$params
+      $cou0008[[6]]$params$dfAnalyzed
+      [1] "Analysis_Analyzed"
+      
+      $cou0008[[6]]$params$vThreshold
+      [1] "vThreshold"
+      
+      
+      
+      $cou0008[[7]]
+      $cou0008[[7]]$name
+      [1] "Summarize"
+      
+      $cou0008[[7]]$output
+      [1] "Analysis_Summary"
+      
+      $cou0008[[7]]$params
+      $cou0008[[7]]$params$dfFlagged
+      [1] "Analysis_Flagged"
+      
+      $cou0008[[7]]$params$nMinDenominator
       [1] "nMinDenominator"
       
       


### PR DESCRIPTION
## Overview
Updated `spec`s in `inst/metrics` yamls to include:
- `type` field to allow for validation in `CheckSpec()`
- all columns needed to perform queries in the workflow.

closes #1778
closes #1807 

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

