### PR TITLE
Closes #1722 Study Status Table display bugfix of indiscriminant first five attributes

### DIFF
--- a/R/Report_StudyInfo.R
+++ b/R/Report_StudyInfo.R
@@ -49,7 +49,7 @@ Report_StudyInfo <- function(
     )
 
   show_table <- study_status_table %>%
-    dplyr::filter(Param %in% c("StudyID", "nickname", "enrolled_sites", "enrolled_participants")) %>%
+    dplyr::filter(Param %in% c("GroupID", "nickname", "Status", "SiteCount", "ParticipantCount")) %>%
     dplyr::select("Description", "Value") %>%
     gsm_gt(id = "study_table")
 

--- a/R/Report_StudyInfo.R
+++ b/R/Report_StudyInfo.R
@@ -50,13 +50,13 @@ Report_StudyInfo <- function(
 
   show_table <- study_status_table %>%
     dplyr::filter(Param %in% c("StudyID", "nickname", "enrolled_sites", "enrolled_participants")) %>%
-    gsm_gt(id = "study_table") %>%
-    dplyr::select("Description", "Value")
+    dplyr::select("Description", "Value") %>%
+    gsm_gt(id = "study_table")
 
 
   hide_table <- study_status_table %>%
-    gsm_gt(id = "study_table_hide") %>%
-    dplyr::select("Description", "Value")
+    dplyr::select("Description", "Value") %>%
+    gsm_gt(id = "study_table_hide")
 
   toggle_switch <- glue::glue('<label class="toggle">
   <input class="toggle-checkbox btn-show-details" type="checkbox">

--- a/R/Report_StudyInfo.R
+++ b/R/Report_StudyInfo.R
@@ -40,7 +40,6 @@ Report_StudyInfo <- function(
     Value = unname(unlist(lStudy))
   ) %>%
     dplyr::left_join(dfLabels, by = "Param") %>%
-    dplyr::select("Description", "Value") %>%
     dplyr::mutate(
       Value = dplyr::if_else(
         is.na(.data$Value),
@@ -50,11 +49,14 @@ Report_StudyInfo <- function(
     )
 
   show_table <- study_status_table %>%
-    dplyr::slice(1:5) %>%
-    gsm_gt(id = "study_table")
+    dplyr::filter(Param %in% c("StudyID", "nickname", "enrolled_sites", "enrolled_participants")) %>%
+    gsm_gt(id = "study_table") %>%
+    dplyr::select("Description", "Value")
+
 
   hide_table <- study_status_table %>%
-    gsm_gt(id = "study_table_hide")
+    gsm_gt(id = "study_table_hide") %>%
+    dplyr::select("Description", "Value")
 
   toggle_switch <- glue::glue('<label class="toggle">
   <input class="toggle-checkbox btn-show-details" type="checkbox">

--- a/tests/testthat/test-Report_StudyInfo.R
+++ b/tests/testthat/test-Report_StudyInfo.R
@@ -1,4 +1,5 @@
 lStudy <- list(
+  # Are these variable names standardized?
   StudyID = "Unique Study ID",
   protocol_title = "Study Title",
   nickname = "Nickname",

--- a/tests/testthat/test-Report_StudyInfo.R
+++ b/tests/testthat/test-Report_StudyInfo.R
@@ -1,5 +1,4 @@
 lStudy <- list(
-  # Are these variable names standardized?
   StudyID = "Unique Study ID",
   protocol_title = "Study Title",
   nickname = "Nickname",


### PR DESCRIPTION
## Overview

- Use of `slice(1:5)` contributed to indiscriminant first five attributes
- To fix, need to find some sort of logic that grabs: protocol id, nickname, and site/participant numbers
- Took a look at the `testthat` file that corresponded to `Report_StudyInfo()` to grab what looked like controlled terminology/standard convention names

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

