### PR TITLE
Add type validation to `CheckSpec()`

### DIFF
--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -53,7 +53,24 @@ CheckSpec <- function(lData, lSpec) {
   # Check that all required columns in the spec are present in the data
   allCols <- c()
   missingCols <- c()
+  wrongType <- c()
   for (strDataFrame in lSpecDataFrames) {
+    #check modes in data
+    imap(lSpec[[strDataFrame]], \(x, idx) {
+      if (!is.null(x$type)) {
+        #check if data is the expected mode
+        res <- x$type %in% mode(lData[[strDataFrame]][[idx]])
+        if (!res) {
+          wrongType <- c(wrongType, idx)
+        }
+      }
+    })
+    if (length(wrongType) > 0) {
+      cli::cli_alert_danger("Not all columns of {strDataFrame} in the spec are in the expected format, improperly formatted columns are: {wrongType}")
+    } else {
+      cli::cli_alert("All specified columns in {strDataFrame} are in the expected format")
+    }
+    #check that required exist in data
     lSpecColumns <- which(sapply(lSpec[[strDataFrame]], function(x) x$required)) %>% names
     lDataColumns <- names(lData[[strDataFrame]])
     allCols <- c(allCols, paste(strDataFrame, lSpecColumns, sep = "$"))

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -54,18 +54,25 @@ CheckSpec <- function(lData, lSpec) {
   allCols <- c()
   missingCols <- c()
   for (strDataFrame in lSpecDataFrames) {
-    wrongType <- c()
+    chrDataFrameColnames <- colnames(lData[[strDataFrame]])
     #check modes in data
-    imap(lSpec[[strDataFrame]], \(x, idx) {
-      if (!is.null(x$type)) {
-        #check if data is the expected mode
-        res <- x$type %in% mode(lData[[strDataFrame]][[idx]])
-        if (!res) {
-          wrongType <<- c(wrongType, idx)
+    wrongType <- purrr::reduce2(
+      lSpec[[strDataFrame]],
+      names(lSpec[[strDataFrame]]),
+      function(so_far, x, idx) {
+        if (!is.null(x$type) && idx %in% chrDataFrameColnames) {
+          #check if data is the expected mode
+          res <- all(x$type %in% mode(lData[[strDataFrame]][[idx]]))
+          if (!res) {
+            so_far <- c(so_far, idx)
+          }
+          return(so_far)
         }
-      }
-    })
-    if (length(wrongType) > 0) {
+      },
+      .init = character()
+    )
+
+    if (length(wrongType)) {
       cli::cli_alert_danger("Not all columns of {strDataFrame} in the spec are in the expected format, improperly formatted columns are: {wrongType}")
     } else {
       cli::cli_alert("All specified columns in {strDataFrame} are in the expected format")

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -53,15 +53,15 @@ CheckSpec <- function(lData, lSpec) {
   # Check that all required columns in the spec are present in the data
   allCols <- c()
   missingCols <- c()
-  wrongType <- c()
   for (strDataFrame in lSpecDataFrames) {
+    wrongType <- c()
     #check modes in data
     imap(lSpec[[strDataFrame]], \(x, idx) {
       if (!is.null(x$type)) {
         #check if data is the expected mode
         res <- x$type %in% mode(lData[[strDataFrame]][[idx]])
         if (!res) {
-          wrongType <- c(wrongType, idx)
+          wrongType <<- c(wrongType, idx)
         }
       }
     })

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -62,7 +62,7 @@ CheckSpec <- function(lData, lSpec) {
       function(so_far, x, idx) {
         if (!is.null(x$type) && idx %in% chrDataFrameColnames) {
           #check if data is the expected mode
-          res <- all(x$type %in% mode(lData[[strDataFrame]][[idx]]))
+          res <- all(x$type == mode(lData[[strDataFrame]][[idx]]))
           if (!res) {
             so_far <- c(so_far, idx)
           }

--- a/tests/testthat/test-util-checkSpec.R
+++ b/tests/testthat/test-util-checkSpec.R
@@ -90,3 +90,33 @@ test_that("Missing column only gets a flag when it is required", {
   )
 
 })
+
+test_that("Validate column type works", {
+  lData <- list(reporting_results = gsm::reportingResults)
+  lSpec <- list(
+    reporting_results = list(
+      GroupID = list(required = TRUE, type = "character"),
+      GroupLevel = list(required = TRUE, type = "character"),
+      Numerator = list(required = TRUE, type = "numeric"),
+      Denominator = list(required = TRUE, type = "numeric")
+    )
+  )
+  expect_message(
+    CheckSpec(lData, lSpec),
+    regexp = "All specified columns"
+  )
+
+  lSpec <- list(
+    reporting_results = list(
+      GroupID = list(required = TRUE, type = "character"),
+      GroupLevel = list(required = TRUE, type = "character"),
+      Numerator = list(required = TRUE, type = "character"),
+      Denominator = list(required = TRUE, type = "numeric")
+    )
+  )
+  expect_message(
+    CheckSpec(lData, lSpec),
+    regexp = "Not all columns"
+  )
+
+})

--- a/tests/testthat/test-util-checkSpec.R
+++ b/tests/testthat/test-util-checkSpec.R
@@ -1,27 +1,44 @@
-# example lSpec
-lSpec <- list(
-  df1 = list(
-    a = list(required = TRUE),
-    b = list(required = TRUE)
-  ),
-  df2 = list(
-    x = list(required = TRUE),
-    y = list(required = TRUE)
-  )
-)
-
-
 test_that("All data.frames and columns are present", {
+  # example lSpec
+  lSpec <- list(
+    df1 = list(
+      a = list(required = TRUE),
+      b = list(required = TRUE)
+    ),
+    df2 = list(
+      x = list(required = TRUE),
+      y = list(required = TRUE)
+    )
+  )
+
   # Example data
   lData <- list(
     df1 = data.frame(a = 1:3, b = 4:6),
     df2 = data.frame(x = 7:9, y = 10:12)
   )
 
-  expect_message(CheckSpec(lData, lSpec), "All")
+  expect_message(
+    expect_message(expect_message(
+      expect_message(CheckSpec(lData, lSpec), "All 2 data"),
+      "All specified"
+    ), "All specified"),
+    "All 4 required"
+  )
 })
 
 test_that("Missing data.frames trigger an error", {
+  # example lSpec
+  lSpec <- list(
+    df1 = list(
+      a = list(required = TRUE),
+      b = list(required = TRUE)
+    ),
+    df2 = list(
+      x = list(required = TRUE),
+      y = list(required = TRUE)
+    )
+  )
+
   # Example data with one missing data.frame
   lData <- list(
     df1 = data.frame(a = 1:3, b = 4:6)
@@ -34,6 +51,18 @@ test_that("Missing data.frames trigger an error", {
 })
 
 test_that("Missing columns trigger a warning", {
+  # example lSpec
+  lSpec <- list(
+    df1 = list(
+      a = list(required = TRUE),
+      b = list(required = TRUE)
+    ),
+    df2 = list(
+      x = list(required = TRUE),
+      y = list(required = TRUE)
+    )
+  )
+
   # Example data with a missing column
   lData <- list(
     df1 = data.frame(a = 1:3),
@@ -41,12 +70,24 @@ test_that("Missing columns trigger a warning", {
   )
 
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(expect_message(CheckSpec(lData, lSpec), "All 2 data"), "All specified"), "All specified"),
     regexp = "missing columns are: df1\\$b"
   )
 })
 
 test_that("Multiple missing columns are correctly reported", {
+  # example lSpec
+  lSpec <- list(
+    df1 = list(
+      a = list(required = TRUE),
+      b = list(required = TRUE)
+    ),
+    df2 = list(
+      x = list(required = TRUE),
+      y = list(required = TRUE)
+    )
+  )
+
   # Example data with multiple missing columns
   lData <- list(
     df1 = data.frame(a = 1:3),
@@ -54,7 +95,7 @@ test_that("Multiple missing columns are correctly reported", {
   )
 
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(expect_message(CheckSpec(lData, lSpec), "All 2 data"), "All specified"), "All specified"),
     regexp = "missing columns are: df1\\$b and df2\\$y"
   )
 })
@@ -71,7 +112,7 @@ test_that("Missing column only gets a flag when it is required", {
     )
   )
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(CheckSpec(lData, lSpec), "All 1 data"), "All specified"),
     regexp = "All 4 required columns"
   )
 
@@ -85,10 +126,9 @@ test_that("Missing column only gets a flag when it is required", {
     )
   )
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(CheckSpec(lData, lSpec), "All 1 data"), "All specified"),
     regexp = "Not all required columns"
   )
-
 })
 
 test_that("Validate column type works", {
@@ -102,7 +142,7 @@ test_that("Validate column type works", {
     )
   )
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(CheckSpec(lData, lSpec), "All 1"), "All 4"),
     regexp = "All specified columns"
   )
 
@@ -115,8 +155,7 @@ test_that("Validate column type works", {
     )
   )
   expect_message(
-    CheckSpec(lData, lSpec),
+    expect_message(expect_message(CheckSpec(lData, lSpec), "All 1"), "All 4"),
     regexp = "Not all columns"
   )
-
 })


### PR DESCRIPTION
## Overview
Added a simple type validation to `CheckSpec()` to ensure the data is coming in in the correct format based on optional `type` field in `spec`. Also added test to ensure we get an error message when there is a format mismatch

closes #1810 

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

Notes: 

