### PR TITLE
Closes #1795 add assertions/stopifnot for widget inputs

### DIFF
--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -41,6 +41,16 @@ Widget_BarChart <- function(
   strShinyGroupSelectID = "GroupID",
   bDebug = FALSE
 ) {
+  stopifnot(
+    "dfResults is not a data.frame" = is.data.frame(dfResults),
+    "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
+    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
+    "strOutcome must be length 1" = length(strOutcome) == 1,
+    "strOutcome is not character" = is.character(strOutcome),
+    "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
+    "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
+    "bDebug is not a logical" = is.logical(bDebug)
+  )
   # Parse `vThreshold` from comma-delimited character string to numeric vector.
   if (!is.null(vThreshold)) {
     if (is.character(vThreshold)) {

--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -46,7 +46,7 @@ Widget_BarChart <- function(
     "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
     "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
     "strOutcome must be length 1" = length(strOutcome) == 1,
-    "strOutcome is not character" = is.character(strOutcome),
+    "strOutcome is not a character" = is.character(strOutcome),
     "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
     "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
     "bDebug is not a logical" = is.logical(bDebug)

--- a/R/Widget_BarChart.R
+++ b/R/Widget_BarChart.R
@@ -43,8 +43,8 @@ Widget_BarChart <- function(
 ) {
   stopifnot(
     "dfResults is not a data.frame" = is.data.frame(dfResults),
-    "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
-    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
+    "lMetric must be a list, but not a data.frame" = is.list(lMetric) && !is.data.frame(lMetric),
+    "dfGroups is not a data.frame" = is.null(dfGroups) || is.data.frame(dfGroups),
     "strOutcome must be length 1" = length(strOutcome) == 1,
     "strOutcome is not a character" = is.character(strOutcome),
     "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),

--- a/R/Widget_FlagOverTime.R
+++ b/R/Widget_FlagOverTime.R
@@ -20,6 +20,12 @@ Widget_FlagOverTime <- function(
   dfMetrics,
   strGroupLevel = c("Site", "Study", "Country")
 ) {
+  stopifnot(
+    "dfResults is not a data.frame" = is.data.frame(dfResults),
+    "dfMetrics is not a data.frame" = is.data.frame(dfMetrics),
+    "strGroupLevel is not a character" = is.character(strGroupLevel)
+  )
+
   gtFlagOverTime <- Report_FlagOverTime(
     dfResults,
     dfMetrics,

--- a/R/Widget_GroupOverview.R
+++ b/R/Widget_GroupOverview.R
@@ -51,6 +51,15 @@ Widget_GroupOverview <- function(
   strGroupLabelKey = "InvestigatorLastName",
   bDebug = FALSE
 ) {
+  stopifnot(
+    "dfResults is not a data.frame" = is.data.frame(dfResults),
+    "dfMetrics is not a data.frame" = is.data.frame(dfMetrics),
+    "dfGroups is not a data.frame" = is.data.frame(dfGroups),
+    "strGroupSubset is not a character" = is.character(strGroupSubset),
+    "strGroupLabelKey is not a character" = is.character(strGroupLabelKey),
+    "bDebug is not a logical" = is.logical(bDebug)
+  )
+
   # set strGroupLevel if NULL and dfMetrics is not NULL
   if (is.null(strGroupLevel) && !is.null(dfMetrics)) {
     strGroupLevel <- unique(dfMetrics$GroupLevel)

--- a/R/Widget_ScatterPlot.R
+++ b/R/Widget_ScatterPlot.R
@@ -40,6 +40,15 @@ Widget_ScatterPlot <- function(
   strShinyGroupSelectID = "GroupID",
   bDebug = FALSE
 ) {
+  stopifnot(
+    "dfResults is not a data.frame" = is.data.frame(dfResults),
+    "lMetric must be a list, but not a data.frame" = is.list(lMetric) && !is.data.frame(lMetric),
+    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
+    "dfBounds is not a data.frame" = is.null(dfBounds) | is.data.frame(dfBounds),
+    "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
+    "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
+    "bDebug is not a logical" = is.logical(bDebug)
+  )
   # define widget inputs
   input <- list(
     dfResults = dfResults,

--- a/R/Widget_ScatterPlot.R
+++ b/R/Widget_ScatterPlot.R
@@ -43,8 +43,8 @@ Widget_ScatterPlot <- function(
   stopifnot(
     "dfResults is not a data.frame" = is.data.frame(dfResults),
     "lMetric must be a list, but not a data.frame" = is.list(lMetric) && !is.data.frame(lMetric),
-    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
-    "dfBounds is not a data.frame" = is.null(dfBounds) | is.data.frame(dfBounds),
+    "dfGroups is not a data.frame" = is.null(dfGroups) || is.data.frame(dfGroups),
+    "dfBounds is not a data.frame" = is.null(dfBounds) || is.data.frame(dfBounds),
     "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
     "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
     "bDebug is not a logical" = is.logical(bDebug)

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -40,6 +40,16 @@ Widget_TimeSeries <- function(
   strShinyGroupSelectID = "GroupID",
   bDebug = FALSE
 ) {
+  stopifnot(
+    "dfResults is not a data.frame" = is.data.frame(dfResults),
+    "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
+    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
+    "strOutcome must be length 1" = length(strOutcome) == 1,
+    "strOutcome is not character" = is.character(strOutcome),
+    "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
+    "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
+    "bDebug is not a logical" = is.logical(bDebug)
+  )
   # Parse `vThreshold` from comma-delimited character string to numeric vector.
   if (!is.null(vThreshold)) {
     if (is.character(vThreshold)) {

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -43,7 +43,7 @@ Widget_TimeSeries <- function(
   stopifnot(
     "dfResults is not a data.frame" = is.data.frame(dfResults),
     "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
-    "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
+    "dfGroups is not a data.frame" = is.null(dfGroups) || is.data.frame(dfGroups),
     "strOutcome must be length 1" = length(strOutcome) == 1,
     "strOutcome is not a character" = is.character(strOutcome),
     "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),

--- a/R/Widget_TimeSeries.R
+++ b/R/Widget_TimeSeries.R
@@ -45,7 +45,7 @@ Widget_TimeSeries <- function(
     "lMetric must be a list, but not a data.frame" = is.list(lMetric) & !is.data.frame(lMetric),
     "dfGroups is not a data.frame" = is.null(dfGroups) | is.data.frame(dfGroups),
     "strOutcome must be length 1" = length(strOutcome) == 1,
-    "strOutcome is not character" = is.character(strOutcome),
+    "strOutcome is not a character" = is.character(strOutcome),
     "bAddGroupSelect is not a logical" = is.logical(bAddGroupSelect),
     "strShinyGroupSelectID is not a character" = is.character(strShinyGroupSelectID),
     "bDebug is not a logical" = is.logical(bDebug)

--- a/tests/testthat/test-Widget_FlagOverTime.R
+++ b/tests/testthat/test-Widget_FlagOverTime.R
@@ -12,3 +12,20 @@ test_that("Widget_FlagOverTime creates a valid HTML widget", {
     )
   )
 })
+
+test_that("Widget_FlagOverTime assertions works", {
+  reportingResults_modified <- as.list(reportingResults)
+  reportingMetrics_modified <- as.list(reportingMetrics)
+  expect_error(
+    Widget_FlagOverTime(reportingResults_modified, reportingMetrics, strGroupLevel = "Site"),
+    "dfResults is not a data.frame"
+  )
+  expect_error(
+    Widget_FlagOverTime(reportingResults, reportingMetrics_modified, strGroupLevel = "Site"),
+    "dfMetrics is not a data.frame"
+  )
+  expect_error(
+    Widget_FlagOverTime(reportingResults, reportingMetrics, strGroupLevel = 1),
+    "strGroupLevel is not a character"
+  )
+})

--- a/tests/testthat/test-Widget_GroupOverview.R
+++ b/tests/testthat/test-Widget_GroupOverview.R
@@ -30,3 +30,33 @@ test_that("Widget_GroupOverview uses correct Group or errors out when strGroupLe
     jsonlite::toJSON(na = "string", auto_unbox = T)
   expect_equal(widget$x$strGroupLevel, sampleGroupLevel)
 })
+
+test_that("Widget_GroupOverview assertions works", {
+  reportingResults_modified <- as.list(reportingResults)
+  reportingMetrics_modified <- as.list(reportingMetrics)
+  reportingGroups_modified <- as.list(reportingGroups)
+  expect_error(
+    Widget_GroupOverview(reportingResults_modified, reportingMetrics, reportingGroups),
+    "dfResults is not a data.frame"
+  )
+  expect_error(
+    Widget_GroupOverview(reportingResults, reportingMetrics_modified, reportingGroups),
+    "dfMetrics is not a data.frame"
+  )
+  expect_error(
+    Widget_GroupOverview(reportingResults, reportingMetrics, reportingGroups_modified),
+    "dfGroups is not a data.frame"
+  )
+  expect_error(
+    Widget_GroupOverview(reportingResults, reportingMetrics, reportingGroups, strGroupSubset = 1),
+    "strGroupSubset is not a character"
+  )
+  expect_error(
+    Widget_GroupOverview(reportingResults, reportingMetrics, reportingGroups, strGroupLabelKey = 1),
+    "strGroupLabelKey is not a character"
+  )
+  expect_error(
+    Widget_GroupOverview(reportingResults, reportingMetrics, reportingGroups, bDebug = 1),
+    "bDebug is not a logical"
+  )
+})

--- a/tests/testthat/test_Widget_BarChart.R
+++ b/tests/testthat/test_Widget_BarChart.R
@@ -40,3 +40,60 @@ test_that("Widget_BarChart processes dfGRoups correctly", {
   reportingGroups_json <- jsonlite::toJSON(reportingGroups, na = "string")
   expect_equal(widget$x$dfGroups, reportingGroups_json)
 })
+
+test_that("Widget_BarChart assertions works", {
+  reportingResults_modified <- as.list(reportingResults)
+  reportingGroups_modified <- as.list(reportingGroups)
+  expect_error(
+    Widget_BarChart(
+      reportingResults_modified,
+      reportingMetrics %>% as.list()
+    ),
+    "dfResults is not a data.frame"
+  )
+  expect_error(
+    Widget_BarChart(reportingResults, reportingMetrics),
+    "lMetric must be a list, but not a data.frame"
+  )
+  expect_error(
+    Widget_BarChart(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      reportingGroups_modified
+    ),
+    "dfGroups is not a data.frame"
+  )
+  expect_error(
+    Widget_BarChart(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      strOutcome = 1
+    ),
+    "strOutcome is not a character"
+  )
+  expect_error(
+    Widget_BarChart(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bAddGroupSelect = NULL
+    ),
+    "bAddGroupSelect is not a logical"
+  )
+  expect_error(
+    Widget_BarChart(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      strShinyGroupSelectID = 1
+    ),
+    "strShinyGroupSelectID is not a character"
+  )
+  expect_error(
+    Widget_BarChart(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bDebug = NULL
+    ),
+    "bDebug is not a logical"
+  )
+})
+

--- a/tests/testthat/test_Widget_ScatterPlot.R
+++ b/tests/testthat/test_Widget_ScatterPlot.R
@@ -33,3 +33,61 @@ test_that("Widget_ScatterPlot processes dfGroups correctly", {
   dfGroups_json <- jsonlite::toJSON(reportingGroups, na = "string")
   expect_equal(widget$x$dfGroups, dfGroups_json)
 })
+
+test_that("Widget_ScatterPlot assertions works", {
+  reportingResults_modified <- as.list(reportingResults)
+  reportingGroups_modified <- as.list(reportingGroups)
+  reportingBounds_modified <- as.list(reportingBounds)
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults_modified,
+      reportingMetrics %>% as.list()
+    ),
+    "dfResults is not a data.frame"
+  )
+  expect_error(
+    Widget_ScatterPlot(reportingResults, reportingMetrics),
+    "lMetric must be a list, but not a data.frame"
+  )
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      reportingGroups_modified
+    ),
+    "dfGroups is not a data.frame"
+  )
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      reportingGroups,
+      reportingBounds_modified
+    ),
+    "dfBounds is not a data.frame"
+  )
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bAddGroupSelect = NULL
+    ),
+    "bAddGroupSelect is not a logical"
+  )
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      strShinyGroupSelectID = 1
+    ),
+    "strShinyGroupSelectID is not a character"
+  )
+  expect_error(
+    Widget_ScatterPlot(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bDebug = NULL
+    ),
+    "bDebug is not a logical"
+  )
+})

--- a/tests/testthat/test_Widget_TimeSeries.R
+++ b/tests/testthat/test_Widget_TimeSeries.R
@@ -36,3 +36,59 @@ test_that("Widget_TimeSeries sets vThreshold correctly", {
   vThreshold_json <- jsonlite::toJSON(vThreshold, na = "string")
   expect_equal(widget$x$vThreshold, vThreshold_json)
 })
+
+test_that("Widget_TimeSeries assertions works", {
+  reportingResults_modified <- as.list(reportingResults)
+  reportingGroups_modified <- as.list(reportingGroups)
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults_modified,
+      reportingMetrics %>% as.list()
+    ),
+    "dfResults is not a data.frame"
+  )
+  expect_error(
+    Widget_TimeSeries(reportingResults, reportingMetrics),
+    "lMetric must be a list, but not a data.frame"
+  )
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      reportingGroups_modified
+    ),
+    "dfGroups is not a data.frame"
+  )
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      strOutcome = 1
+    ),
+    "strOutcome is not a character"
+  )
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bAddGroupSelect = NULL
+    ),
+    "bAddGroupSelect is not a logical"
+  )
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      strShinyGroupSelectID = 1
+    ),
+    "strShinyGroupSelectID is not a character"
+  )
+  expect_error(
+    Widget_TimeSeries(
+      reportingResults,
+      reportingMetrics %>% as.list(),
+      bDebug = NULL
+    ),
+    "bDebug is not a logical"
+  )
+})


### PR DESCRIPTION
## Overview
- `stopifnot()` chunk was added at the beginning of each widget app

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1795 

