### PR TITLE
skip `Analysis_` checks in checkSpec

### DIFF
--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -38,7 +38,7 @@
 #'
 CheckSpec <- function(lData, lSpec) {
   # Check that all data.frames in the spec are present in the data
-  lSpecDataFrames <- names(lSpec)
+  lSpecDataFrames <- Reduce(\(x, y) grep(y, x, value = TRUE, invert = TRUE), "Analysis", names(lSpec))
   lDataFrames <- names(lData)
   if (!all(lSpecDataFrames %in% lDataFrames)) {
     MissingSpecDataFrames <- lSpecDataFrames[!lSpecDataFrames %in% lDataFrames]


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
experimental `Analysis` spec specification is causing issues in workflows, so skipping `Analysis_*` dfs in `checkSpec()` temporarily to prevent workflow failures. 



## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->
Filed a new issue to re-examine this once spec formatting for `lAnalysis` has been solidified (#1838)

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1837 

