### PR TITLE
make analysis workflow work

### DIFF
--- a/R/RunStep.R
+++ b/R/RunStep.R
@@ -83,7 +83,7 @@ RunStep <- function(lStep, lData, lMeta, lSpec = NULL) {
       } else if (paramVal %in% names(lData)) {
         cli::cli_alert_success("{paramName} = {paramVal}: Passing lData${paramVal}.")
         params[[paramName]] <- lData[[paramVal]]
-      }  else {
+      } else {
         # If the parameter value is not found in 'lMeta' or 'lData', pass the parameter value as a string.
         cli::cli_alert_info("{paramName} = {paramVal}: No matching data found. Passing '{paramVal}' as a string.")
       }
@@ -94,5 +94,6 @@ RunStep <- function(lStep, lData, lMeta, lSpec = NULL) {
   }
 
   cli::cli_h3("Calling {.fn {lStep$name}}")
+
   return(do.call(lStep$name, params))
 }

--- a/R/RunWorkflow.R
+++ b/R/RunWorkflow.R
@@ -104,7 +104,7 @@ RunWorkflow <- function(
     cli::cli_alert_info("Returning workflow inputs and outputs: {names(lWorkflow$lData)}")
   }
 
-  cli::cli_h1(paste0("Completed `", lWorkflow$meta$File, "` Workflow"))
+  cli::cli_h1("Completed `{lWorkflow$meta$File}` Workflow")
 
   # Save data.
   if (!is.null(lInputConfig)) {

--- a/R/RunWorkflow.R
+++ b/R/RunWorkflow.R
@@ -74,7 +74,12 @@ RunWorkflow <- function(
   for (step in lWorkflow$steps) {
     cli::cli_h2(paste0("Workflow Step ", stepCount, " of ", length(lWorkflow$steps), ": `", step$name, "`"))
 
-    result <- RunStep(lStep = step, lData = lWorkflow$lData, lMeta = lWorkflow$meta, lSpec = lWorkflow$spec)
+    result <- RunStep(
+        lStep = step,
+        lData = lWorkflow$lData,
+        lMeta = lWorkflow$meta,
+        lSpec = lWorkflow$spec
+    )
 
     if (step$output %in% names(lData)) {
       cli::cli_alert_warning("Overwriting existing data in `lData`.")

--- a/R/RunWorkflows.R
+++ b/R/RunWorkflows.R
@@ -28,13 +28,13 @@ RunWorkflows <- function(
   if (length(lWorkflows) > 1) {
     # if there are multiple workflows, run them all
     cli::cli_h1("Running {length(lWorkflows)} Workflows")
+
     lResults <- purrr::map(
       lWorkflows,
       ~ RunWorkflow(.x, lData, lInputConfig, bReturnData, bKeepInputData)
     ) %>% setNames(names(lWorkflows))
   } else {
     # if there is only one workflow, run it
-    print(names(lWorkflows[[1]]))
     lResults <- RunWorkflow(lWorkflow = lWorkflows[[1]], lData, lInputConfig, bReturnData, bKeepInputData)
   }
   return(lResults)

--- a/R/util-BindResults.R
+++ b/R/util-BindResults.R
@@ -24,7 +24,7 @@ BindResults <- function(
   lAnalysis,
   strName,
   dSnapshotDate = Sys.Date(),
-  strStudyID,
+  strStudyID = NULL,
   bUselData = FALSE
 ) {
   dfResults <- lAnalysis %>%
@@ -38,10 +38,15 @@ BindResults <- function(
         return(subResult %>% dplyr::mutate(MetricID = metric))
       }
     ) %>%
-    purrr::list_rbind() %>%
-    dplyr::mutate(
-      SnapshotDate = dSnapshotDate,
-      StudyID = strStudyID
-    )
+    purrr::list_rbind()
+
+  if (!is.null(dSnapshotDate)) {
+    dfResults$SnapshotDate <- dSnapshotDate
+  }
+
+  if (!is.null(strStudyID)) {
+    dfResults$StudyID <- strStudyID
+  }
+
   return(dfResults)
 }

--- a/inst/workflow/1_ingest.yaml
+++ b/inst/workflow/1_ingest.yaml
@@ -6,20 +6,38 @@ spec:
     protocol_number:
       required: true
       type: character
+      #target_col: studyid
+    nickname:
+      required: true
+      type: character
+    protocol_title:
+      required: true
+      type: character
     status:
       required: true
       type: character
+    num_plan_site:
+      required: true
+      type: numeric
+    num_plan_subj:
+      required: true
+      type: numeric
   Source_SITE:
+    protocol:
+      required: true
+      type: character
+      #target_col: studyid
     pi_number:
       required: true
       type: character
-    site_status:
-      required: true
-      type: character
+      #target_col: invid
     pi_first_name:
       required: true
       type: character
     pi_last_name:
+      required: true
+      type: character
+    site_status:
       required: true
       type: character
     city:
@@ -136,8 +154,8 @@ spec:
       required: true
       type: character
 steps:
-  - name: Ingest
-    output: lRaw
+  - output: lRaw
+    name: Ingest
     params:
       lSourceData: lData
       lSpec: lSpec

--- a/inst/workflow/2_map.yaml
+++ b/inst/workflow/2_map.yaml
@@ -99,7 +99,7 @@ steps:
       Temp_CTMSSite: Temp_CTMSSite
       Temp_SiteCounts: Temp_SiteCounts
 
-  # Get Participant and Site counts for Country, Site and Study
+  # Country metadata
   - output: Temp_CountryCountsWide
     name: RunQuery
     params:
@@ -137,35 +137,35 @@ steps:
       "y": Temp_SubjectLookup
       by: subject_nsv
 
-  # Copy Raw_* to Mapped_* for the remaining domains
+  # Copy Raw_* to Mapped_* for the remaining domains.
   - output: Mapped_AE
-    name: <-
+    name: =
     params:
-      name: Mapped_AE
-      value: Raw_AE
+      lhs: lhs
+      rhs: Raw_AE
   - output: Mapped_PD
-    name: <-
+    name: =
     params:
-      name: Mapped_PD
-      value: Raw_PD
+      lhs: lhs
+      rhs: Raw_PD
   - output: Mapped_LB
-    name: <-
+    name: =
     params:
-      name: Mapped_LB
-      value: Raw_LB
+      lhs: lhs
+      rhs: Raw_LB
   - output: Mapped_STUDCOMP
-    name: <-
+    name: =
     params:
-      name: Mapped_STUDCOMP
-      value: Raw_STUDCOMP
+      lhs: lhs
+      rhs: Raw_STUDCOMP
   - output: Mapped_SDRGCOMP
-    name: <-
+    name: =
     params:
-      name: Mapped_SDRGCOMP
-      value: Raw_SDRGCOMP
+      lhs: lhs
+      rhs: Raw_SDRGCOMP
   - output: Mapped_ENROLL
-    name: <-
+    name: =
     params:
-      name: Mapped_ENROLL
-      value: Raw_ENROLL
+      lhs: lhs
+      rhs: Raw_ENROLL
 

--- a/inst/workflow/3_analyze.yaml
+++ b/inst/workflow/3_analyze.yaml
@@ -2,9 +2,6 @@ meta:
   File: 3_analyze.yaml
   Description: run all metrics in a snapshot
 spec:
-  Mapped_SUBJ:
-    _all:
-      required: yes
   Mapped_STUDY:
     _all:
       required: yes
@@ -14,13 +11,7 @@ spec:
   Mapped_COUNTRY:
     _all:
       required: yes
-  Mapped_QUERY:
-    _all:
-      required: yes
-  Mapped_DATAENT:
-    _all:
-      required: yes
-  Mapped_DATACHG:
+  Mapped_SUBJ:
     _all:
       required: yes
   Mapped_AE:
@@ -38,55 +29,87 @@ spec:
   Mapped_SDRGCOMP:
     _all:
       required: yes
+  Mapped_QUERY:
+    _all:
+      required: yes
+  Mapped_DATAENT:
+    _all:
+      required: yes
+  Mapped_DATACHG:
+    _all:
+      required: yes
   Mapped_ENROLL:
     _all:
       required: yes
 steps:
   # Run metric workflows.
-  - name: MakeWorkflowList
-    output: lWorkflows
+  - output: lWorkflows
+    name: MakeWorkflowList
     params:
       strPath: workflow/metrics
-  - name: MakeMetric
-    output: Reporting_Metrics
+  - output: lMappedData
+    name: list
+    params:
+      Mapped_SUBJ: Mapped_SUBJ
+      Mapped_AE: Mapped_AE
+      Mapped_PD: Mapped_PD
+      Mapped_LB: Mapped_LB
+      Mapped_STUDCOMP: Mapped_STUDCOMP
+      Mapped_SDRGCOMP: Mapped_SDRGCOMP
+      Mapped_QUERY: Mapped_QUERY
+      Mapped_DATAENT: Mapped_DATAENT
+      Mapped_DATACHG: Mapped_DATACHG
+      Mapped_ENROLL: Mapped_ENROLL
+  - output: lAnalysis
+    name: RunWorkflows
     params:
       lWorkflows: lWorkflows
-  - name: RunWorkflows
-    output: lAnalysis
-    params:
-      lWorkflows: lWorkflows
-      lData: lData # output of 2_map.yaml
+      lData: lMappedData
       bKeepInputData: FALSE
 
-  # Set snapshot date to today.
-  - name: Sys.Date
-    output: dSnapshotDate
-    params: {}
-
   # Capture study ID from the GroupID column in the study metadata.
-  - name: pull
-    output: GroupID
+  - output: GroupID
+    name: pull
     params:
       .data: Mapped_STUDY
       var: GroupID
-  - name: unique
-    output: strStudyID
+  - output: strStudyID
+    name: unique
     params:
       x: GroupID
 
   # Bind results.
-  - name: BindResults
-    output: Analysis_Input
+  - output: Analysis_Metrics
+    name: MakeMetric
+    params:
+      lWorkflows: lWorkflows
+  - output: Analysis_Input
+    name: BindResults
     params:
       lAnalysis: lAnalysis
       strName: "Analysis_Input"
-      dSnapshotDate: dSnapshotDate
       strStudyID: strStudyID
-  - name: BindResults
-    output: Analysis_Summary
+  - output: Analysis_Summary
+    name: BindResults
     params:
       lAnalysis: lAnalysis
       strName: "Analysis_Summary"
-      dSnapshotDate: dSnapshotDate
       strStudyID: strStudyID
+
+  # Keep mapped data needed in the reporting data model.
+  - output: Mapped_STUDY
+    name: =
+    params:
+      lhs: lhs
+      rhs: Mapped_STUDY
+  - output: Mapped_SITE
+    name: =
+    params:
+      lhs: lhs
+      rhs: Mapped_SITE
+  - output: Mapped_COUNTRY
+    name: =
+    params:
+      lhs: lhs
+      rhs: Mapped_COUNTRY
 

--- a/inst/workflow/3_analyze.yaml
+++ b/inst/workflow/3_analyze.yaml
@@ -1,8 +1,55 @@
 meta:
   File: 3_analyze.yaml
   Description: run all metrics in a snapshot
+spec:
+  Mapped_SUBJ:
+    _all:
+      required: yes
+  Mapped_STUDY:
+    _all:
+      required: yes
+  Mapped_SITE:
+    _all:
+      required: yes
+  Mapped_COUNTRY:
+    _all:
+      required: yes
+  Mapped_QUERY:
+    _all:
+      required: yes
+  Mapped_DATAENT:
+    _all:
+      required: yes
+  Mapped_DATACHG:
+    _all:
+      required: yes
+  Mapped_AE:
+    _all:
+      required: yes
+  Mapped_PD:
+    _all:
+      required: yes
+  Mapped_LB:
+    _all:
+      required: yes
+  Mapped_STUDCOMP:
+    _all:
+      required: yes
+  Mapped_SDRGCOMP:
+    _all:
+      required: yes
+  Mapped_ENROLL:
+    _all:
+      required: yes
 steps:
-  # Run Metrics
+  # Encapsulate individual mapped data frames in a list.
+  - name: <-
+    output: lMapped
+    params:
+      lhs: lMapped
+      rhs: lData
+
+  # Run metric workflows.
   - name: MakeWorkflowList
     output: lWorkflows
     params:
@@ -13,3 +60,36 @@ steps:
       lWorkflows: lWorkflows
       lData: lMapped
       bKeepInputData: FALSE
+
+  # Set snapshot date to today.
+  - name: Sys.Date
+    output: dSnapshotDate
+    params: {}
+
+  # Capture study ID from the GroupID column in the study metadata.
+  - name: pull
+    output: GroupID
+    params:
+      .data: Mapped_STUDY
+      var: GroupID
+  - name: unique
+    output: strStudyID
+    params:
+      x: GroupID
+
+  # Bind results.
+  - name: BindResults
+    output: Analysis_Input
+    params:
+      lAnalysis: lAnalysis
+      strName: "Analysis_Input"
+      dSnapshotDate: dSnapshotDate
+      strStudyID: strStudyID
+  - name: BindResults
+    output: Analysis_Summary
+    params:
+      lAnalysis: lAnalysis
+      strName: "Analysis_Summary"
+      dSnapshotDate: dSnapshotDate
+      strStudyID: strStudyID
+

--- a/inst/workflow/3_analyze.yaml
+++ b/inst/workflow/3_analyze.yaml
@@ -42,23 +42,20 @@ spec:
     _all:
       required: yes
 steps:
-  # Encapsulate individual mapped data frames in a list.
-  - name: <-
-    output: lMapped
-    params:
-      lhs: lMapped
-      rhs: lData
-
   # Run metric workflows.
   - name: MakeWorkflowList
     output: lWorkflows
     params:
       strPath: workflow/metrics
+  - name: MakeMetric
+    output: Reporting_Metrics
+    params:
+      lWorkflows: lWorkflows
   - name: RunWorkflows
     output: lAnalysis
     params:
       lWorkflows: lWorkflows
-      lData: lMapped
+      lData: lData # output of 2_map.yaml
       bKeepInputData: FALSE
 
   # Set snapshot date to today.

--- a/inst/workflow/4_reporting.yaml
+++ b/inst/workflow/4_reporting.yaml
@@ -16,17 +16,17 @@ steps:
   - name: bind_rows
     output: Reporting_Groups
     params:
-      Country: Mapped_COUNTRY
-      Site: Mapped_SITE
       Study: Mapped_STUDY
+      Site: Mapped_SITE
+      Country: Mapped_COUNTRY
 
-# Create Metric Medatadata
+  # Create Metric Medatadata
   - name: MakeMetric
     output: Reporting_Metrics
     params:
       lWorkflows: lWorkflows
 
-# Stack dfSummary data into dfResults
+  # Stack dfSummary data into dfResults
   - name: BindResults
     output: Reporting_Results
     params:
@@ -35,7 +35,7 @@ steps:
       dSnapshotDate: dSnapshotDate
       strStudyID: strStudyID
 
-# Calculate Bounds for confidence intervals
+  # Calculate Bounds for confidence intervals
   - name: MakeBounds
     output: Reporting_Bounds
     params:

--- a/inst/workflow/4_reporting.yaml
+++ b/inst/workflow/4_reporting.yaml
@@ -2,42 +2,45 @@ meta:
   File: reporting.yaml
   description: Generate reporting data model including site-, country- and study-level metadata (dfGroups), metric metadata (dfMetrics) and results data with added study-level columsn (dfSummary and dfBounds).
 spec: 
-  Mapped_COUNTRY:
+  Mapped_STUDY:
     _all:
       required: true
   Mapped_SITE:
     _all:
       required: true
-  Mapped_STUDY:
+  Mapped_COUNTRY:
+    _all:
+      required: true
+  Analysis_Metrics:
+    _all:
+      required: true
+  Analysis_Summary:
     _all:
       required: true
 steps:
-  # Combine CTMS and Counts data as dfGroups
-  - name: bind_rows
-    output: Reporting_Groups
+  # Copy data defined in analysis step to reporting step.
+  - output: Reporting_Metrics
+    name: =
+    params:
+      lhs: lhs
+      rhs: Analysis_Metrics
+  - output: Reporting_Results
+    name: =
+    params:
+      lhs: lhs
+      rhs: Analysis_Summary
+
+  # Combine group-level metadata and site/participant counts.
+  - output: Reporting_Groups
+    name: bind_rows
     params:
       Study: Mapped_STUDY
       Site: Mapped_SITE
       Country: Mapped_COUNTRY
 
-  # Create Metric Medatadata
-  - name: MakeMetric
-    output: Reporting_Metrics
-    params:
-      lWorkflows: lWorkflows
-
-  # Stack dfSummary data into dfResults
-  - name: BindResults
-    output: Reporting_Results
-    params:
-      lAnalysis: lAnalysis
-      strName: "Analysis_Summary"
-      dSnapshotDate: dSnapshotDate
-      strStudyID: strStudyID
-
-  # Calculate Bounds for confidence intervals
-  - name: MakeBounds
-    output: Reporting_Bounds
+  # Calculate bounds for confidence intervals.
+  - output: Reporting_Bounds
+    name: MakeBounds
     params:
       dfResults: Reporting_Results
       dfMetrics: Reporting_Metrics

--- a/inst/workflow/5_modules.yaml
+++ b/inst/workflow/5_modules.yaml
@@ -3,12 +3,12 @@ meta:
   Description: generate/initialize modules
 steps:
   # Generate Reports
-  - name: MakeWorkflowList
-    output: wf_modules
+  - output: wf_modules
+    name: MakeWorkflowList
     params:
       strPath: workflow/reports
-  - name: RunWorkflows
-    output: lReports
+  - output: lReports
+    name: RunWorkflows
     params:
       lWorkflows: wf_modules
       lData: lData

--- a/inst/workflow/modules/report_kri_country.yaml
+++ b/inst/workflow/modules/report_kri_country.yaml
@@ -32,7 +32,7 @@ steps:
       dfResults: Reporting_Results_Country
       dfGroups: Reporting_Groups
       dfBounds: Reporting_Bounds
-      dfMetrics: Reporting_Metrics
+      dfMetrics: Reporting_Metrics_Country
   - name: Report_KRI
     output: lReport
     params:


### PR DESCRIPTION
## Overview
Updates the `analyze` workflow to run on the output of the `map` workflow. The intent is to allow each of the numbered workflows to run on the output of the previous workflow without any additional variables. One design principle that I'm following is each input to the mapped, analysis, and reporting layers should correspond to a data frame rather than a list of data frames, to align with a database and/or flat file data model.

## Test Notes/Sample Code
```
load_all()

lSourceData <- list(
    Source_STUDY = clindata::ctms_study,
    Source_SITE = clindata::ctms_site,
    Source_SUBJ = clindata::rawplus_dm,
    Source_AE = clindata::rawplus_ae,
    Source_PD = clindata::ctms_protdev,
    Source_LB = clindata::rawplus_lb,
    Source_STUDCOMP = clindata::rawplus_studcomp,
    Source_SDRGCOMP = clindata::rawplus_sdrgcomp,
    Source_QUERY = clindata::edc_queries,
    Source_DATAENT = clindata::edc_data_pages,
    Source_DATACHG = clindata::edc_data_points,
    Source_ENROLL = clindata::rawplus_enroll
)

lIngestWorkflow <- MakeWorkflowList('ingest')[[1]]
lRawData <- Ingest(lSourceData, lIngestWorkflow$spec)

lMapWorkflow <- MakeWorkflowList('map')[[1]]
lMappedData <- RunWorkflow(lMapWorkflow, lRawData)

lAnalyzeWorkflow <- MakeWorkflowList('analyze')[[1]]
lAnalysisData <- RunWorkflow(lAnalyzeWorkflow, lMappedData)

lReportingWorkflow <- MakeWorkflowList('reporting')[[1]]
lReportingData <- RunWorkflow(lReportingWorkflow, lAnalysisData)

lKRIReportBySiteWorkflow <- MakeWorkflowList(strPath = 'workflow/modules')[[2]]
lKRIReportBYSite <- RunWorkflow(lKRIReportBySiteWorkflow, lReportingData)

lKRIReportByCountryWorkflow <- MakeWorkflowList(strPath = 'workflow/modules')[[1]]
lKRIReportBYCountry <- RunWorkflow(lKRIReportByCountryWorkflow, lReportingData)
```

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX

