### PR TITLE
Update `checkSpec()` cli message to handle `_all` required

### DIFF
--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -92,8 +92,8 @@ CheckSpec <- function(lData, lSpec) {
   if (length(missingCols) > 0) {
     cli::cli_alert_danger("Not all required columns in the spec are present in the data, missing columns are: {missingCols}")
   } else if (length(lSpecDataFrames) > 0) {
-    cli::cli_alert("All {length(allCols)} required columns in the spec are present in the data: {allCols}")
+    cli::cli_alert("All {length(allCols)} required column{?s} in the spec are present in the data: {allCols}")
   } else {
-    cli::cli_alert("No required columns specified in the spec. All data.frames are pulling in all available columns")
+    cli::cli_alert("No required columns specified in the spec. All data.frames are pulling in all available columns.")
   }
 }

--- a/R/util-checkSpec.R
+++ b/R/util-checkSpec.R
@@ -91,7 +91,9 @@ CheckSpec <- function(lData, lSpec) {
   }
   if (length(missingCols) > 0) {
     cli::cli_alert_danger("Not all required columns in the spec are present in the data, missing columns are: {missingCols}")
-  } else {
+  } else if (length(lSpecDataFrames) > 0) {
     cli::cli_alert("All {length(allCols)} required columns in the spec are present in the data: {allCols}")
+  } else {
+    cli::cli_alert("No required columns specified in the spec. All data.frames are pulling in all available columns")
   }
 }

--- a/tests/testthat/test-util-checkSpec.R
+++ b/tests/testthat/test-util-checkSpec.R
@@ -192,3 +192,29 @@ test_that("skip column check when `_all` is specified", {
   )
 })
 
+test_that("proper message appears when all data frames require `_all` columns", {
+  # example lSpec
+  lSpec <- list(
+    df1 = list(
+      `_all` = list(required = TRUE)
+    ),
+    df2 = list(
+      `_all` = list(required = TRUE)
+    ),
+    df3 = list(
+      `_all` = list(required = TRUE)
+    )
+  )
+
+  # Example data
+  lData <- list(
+    df1 = data.frame(a = 1:3, b = 4:6),
+    df2 = data.frame(x = 7:9, y = 10:12),
+    df3 = data.frame(z = 1:3, t = 20:22)
+  )
+
+  expect_message(
+    expect_message(CheckSpec(lData, lSpec), "All 3 data"),
+    " No required columns specified"
+  )
+})


### PR DESCRIPTION
## Overview
Adds new message option to handle when all data tables in the spec have `_all` required.
New test added to ensure this message is displayed in proper circumstance

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1845

