### PR TITLE
Closes #1659 and #1660 to use `gt()` instead of `kbl()` in our functions and reports

### DIFF
--- a/R/Report_MetricCharts.R
+++ b/R/Report_MetricCharts.R
@@ -22,7 +22,8 @@ Report_MetricCharts <- function(lCharts, strMetricID = "", overview = FALSE) {
     "barScoreJS",
     "timeSeriesContinuousScoreJS",
     "timeSeriesContinuousMetricJS",
-    "timeSeriesContinuousNumeratorJS"
+    "timeSeriesContinuousNumeratorJS",
+    "metricTable"
   )
 
   chartTypes2 <- c(
@@ -48,7 +49,8 @@ Report_MetricCharts <- function(lCharts, strMetricID = "", overview = FALSE) {
       timeSeriesContinuousMetricJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  KRI Metric"),
       timeSeriesContinuousNumeratorJS = paste0(fontawesome::fa("chart-line", fill = "#337ab7"), "  Numerator"),
       groupOverviewJS = paste0(fontawesome::fa("table", fill = "#337ab7"), "  Group Overview"),
-      flagOverTimeJS = paste0(fontawesome::fa("table", fill = "#337ab7"), "  Flags Over Time")
+      flagOverTimeJS = paste0(fontawesome::fa("table", fill = "#337ab7"), "  Flags Over Time"),
+      metricTable = paste0(fontawesome::fa("table", fill = "#337ab7"), "  Metric Table")
     )
 
     ##### chart tab /

--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -41,12 +41,8 @@ Report_MetricTable <- function(
     return("Nothing flagged for this KRI.")
   }
 
-  SummaryTable <- MetricTable %>%
-    # kableExtra::kbl(format = "html", escape = FALSE) %>%
-    # kableExtra::kable_styling("striped", full_width = FALSE)
+  MetricTable %>%
     gsm_gt() %>%
     fmt_sign_rag(columns = "Flag")
 
-
-  return(SummaryTable)
 }

--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -42,8 +42,11 @@ Report_MetricTable <- function(
   }
 
   SummaryTable <- MetricTable %>%
-    kableExtra::kbl(format = "html", escape = FALSE) %>%
-    kableExtra::kable_styling("striped", full_width = FALSE)
+    # kableExtra::kbl(format = "html", escape = FALSE) %>%
+    # kableExtra::kable_styling("striped", full_width = FALSE)
+    gsm_gt() %>%
+    fmt_sign_rag(columns = "Flag")
+
 
   return(SummaryTable)
 }

--- a/R/util-MakeMetricTable.R
+++ b/R/util-MakeMetricTable.R
@@ -78,7 +78,7 @@ MakeMetricTable <- function(
       desc(abs(.data$Score))
     ) %>%
     dplyr::mutate(
-      Flag = Report_FormatFlag(.data$Flag),
+      # Flag = Report_FormatFlag(.data$Flag),
       dplyr::across(
         dplyr::where(is.numeric),
         ~ round(.x, 2)
@@ -95,6 +95,5 @@ MakeMetricTable <- function(
         "Flag"
       ))
     )
-
   return(MetricTable)
 }

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -143,11 +143,10 @@ for (i in unique(params$dfMetrics$MetricID)) {
 ```{r, echo=FALSE, results='asis'}
 #print dfMetrics table
 params$dfMetrics %>%
-kbl(format="html", escape=FALSE) %>%
-kable_styling ("striped", full_width = FALSE) %>%
-cat
+  gsm_gt(id = "metrics_table")
 
 ```
+
 ```{r echo=FALSE}
 group_dropdown <- system.file('report', 'lib', 'overallGroupDropdown.js', package = "gsm")
 dropdown_drag <- system.file('report', 'lib', 'dragOverallGroupDropdown.js', package = "gsm")

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -132,9 +132,6 @@ for (i in unique(params$dfMetrics$MetricID)) {
     overview = FALSE
   )
 
- params$lCharts[[lMetric$MetricID]]$metricTable %>%
-   cat
-
 }
 
 ```


### PR DESCRIPTION
## Overview


## Test Notes/Sample Code

## Connected Issues

- Closes #1659 
- Closes #1660

