### PR TITLE
Closes #1894 address bug in `Input_Rate()` for 0 row dataframe inputs for dfNumerator/dfDenominator

### DIFF
--- a/R/Input_Rate.R
+++ b/R/Input_Rate.R
@@ -89,13 +89,23 @@ Input_Rate <- function(
   strDenominatorMethod <- match.arg(strDenominatorMethod)
 
   # Check if strNumeratorCol is Null when strNumeratorMethod is 'Sum'
-  if (strNumeratorMethod == "Sum" && is.null(strNumeratorCol)) {
-    stop("strNumeratorCol must be provided when strNumeratorMethod is 'Sum'")
+  if (strNumeratorMethod == "Sum") {
+    if (is.null(strNumeratorCol)) {
+      stop("strNumeratorCol must be provided when strNumeratorMethod is 'Sum'")
+    }
+    if (!is.numeric(dfNumerator[[strNumeratorCol]])) {
+      stop("strNumeratorCol must be numeric when strNumeratorMethod is `Sum`")
+    }
   }
 
   # Check if strDenominatorCol is Null when strDenominatorMethod is 'Sum'
-  if (strDenominatorMethod == "Sum" && is.null(strDenominatorCol)) {
-    stop("strDenominatorCol must be provided when strDenominatorMethod is 'Sum'")
+  if (strDenominatorMethod == "Sum") {
+    if (is.null(strDenominatorCol)) {
+      stop("strDenominatorCol must be provided when strDenominatorMethod is 'Sum'")
+    }
+    if (!is.numeric(dfDenominator[[strDenominatorCol]])) {
+      stop("strDenominatorCol must be numeric when strDenominatorMethod is `Sum`")
+    }
   }
 
   # check that "strSubjectCol" is in all dfs

--- a/R/Input_Rate.R
+++ b/R/Input_Rate.R
@@ -126,18 +126,17 @@ Input_Rate <- function(
   # Calculate Numerator
   dfNumerator_subj <- dfNumerator %>%
     rename(SubjectID = {{ strSubjectCol }}) %>%
-    mutate(Numerator = ifelse(strNumeratorMethod == "Count", 1, .data[[strNumeratorCol]])) %>%
+    mutate(Numerator = if(strNumeratorMethod == "Count") 1 else .data[[strNumeratorCol]]) %>%
     group_by(SubjectID) %>%
-    summarise(Numerator = sum(Numerator, na.rm = TRUE)) %>%
-    ungroup()
+    summarise(Numerator = sum(Numerator, na.rm = TRUE))
 
   # Calculate Denominator
   dfDenominator_subj <- dfDenominator %>%
     rename(SubjectID = {{ strSubjectCol }}) %>%
-    mutate(Denominator = ifelse(strDenominatorMethod == "Count", 1, .data[[strDenominatorCol]])) %>%
+    mutate(Denominator = if(strDenominatorMethod == "Count") 1 else .data[[strDenominatorCol]]) %>%
     group_by(SubjectID) %>%
-    summarise(Denominator = sum(Denominator, na.rm = TRUE)) %>%
-    ungroup()
+    summarise(Denominator = sum(Denominator, na.rm = TRUE))
+
   if (all(dfDenominator_subj$Denominator == 0)) {
     cli::cli_abort(
       "Method {strDenominatorMethod} for {strDenominatorCol} is causing all denominator values to be 0, please check {dfDenominator}"

--- a/R/Input_Rate.R
+++ b/R/Input_Rate.R
@@ -139,7 +139,7 @@ Input_Rate <- function(
 
   if (all(dfDenominator_subj$Denominator == 0)) {
     cli::cli_abort(
-      "Method {strDenominatorMethod} for {strDenominatorCol} is causing all denominator values to be 0, please check {dfDenominator}"
+      "Method `{strDenominatorMethod}` for `{strDenominatorCol}` is causing all denominator values to be 0, please check `dfDenominator`}"
     )
   }
 

--- a/tests/testthat/test-Input_Rate.R
+++ b/tests/testthat/test-Input_Rate.R
@@ -107,6 +107,26 @@ test_that("handling of zero denominators and missing data", {
   expect_equal(result, expected)
 })
 
+test_that("if dfDenominator is incompatible with method and column choice", {
+  subjects <- data.frame(
+    SubjectID = 1:4,
+    GroupID = 10:13
+  )
+  numerators <- data.frame(
+    SubjectID = c(1, 1),
+    GroupID = 10:11
+  )
+  denominators <- data.frame(
+    SubjectID = numeric(),
+    GroupID = numeric()
+  )
+
+  expect_error(
+    Input_Rate(subjects, numerators, denominators),
+    regexp = "causing all denominator values to be 0"
+  )
+})
+
 test_that("yaml workflow produces same table as R function", {
   source(test_path("testdata", "create_double_data.R"), local = TRUE)
   expect_equal(dfInput$SubjectID, lResults$Analysis_kri0001$Analysis_Input$SubjectID)

--- a/tests/testthat/test-Input_Rate.R
+++ b/tests/testthat/test-Input_Rate.R
@@ -107,6 +107,34 @@ test_that("handling of zero denominators and missing data", {
   expect_equal(result, expected)
 })
 
+test_that("if dfNumerator has 0 row data", {
+  subjects <- data.frame(
+    SubjectID = 1:4,
+    GroupID = 10:13
+  )
+  numerators <- data.frame(
+    SubjectID = numeric(),
+    GroupID = numeric()
+  )
+  denominators <- data.frame(
+    SubjectID = c(1, 2),
+    GroupID = 12:13
+  )
+
+  result <- Input_Rate(subjects, numerators, denominators)
+
+  expected <- data.frame(
+    SubjectID = 1:4,
+    GroupID = 10:13,
+    GroupLevel = "GroupID",
+    Numerator = c(0, 0, 0, 0),
+    Denominator = c(1, 1, 0, 0),
+    Metric = c(0, 0, NaN, NaN) # NaN because denominator is zero
+  )
+
+  expect_equal(result, expected)
+})
+
 test_that("if dfDenominator is incompatible with method and column choice", {
   subjects <- data.frame(
     SubjectID = 1:4,


### PR DESCRIPTION
## Overview
Address function/bugs such that it works "as expected"
Add new error messaging for all 0 denominator entry (would cause x/0 NaN on all metric value)

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1897

