### PR TITLE
Fix country overview text

### DIFF
--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -39,7 +39,7 @@ Report_MetricTable <- function(
   )
 
   if (!nrow(MetricTable)) {
-    return("Nothing flagged for this KRI.")
+    return(htmltools::tags$p("Nothing flagged for this KRI."))
   }
 
   cols_to_hide <- c("StudyID", "GroupID", "MetricID")

--- a/R/Report_OverviewText.R
+++ b/R/Report_OverviewText.R
@@ -17,19 +17,18 @@ Report_OverviewText <- function(lSetup, dfResults, lStudy) {
     filter(Flag %in% c(-2, 2, -1, 1)) %>%
     select("GroupID") %>%
     .$GroupID
-  no_alert_groups <- dfResults %>%
-    filter(Flag %in% !c(-2, 2, 1, -1)) %>%
-    select("GroupID") %>%
-    .$GroupID
+  no_alert_groups <- setdiff(dfResults$GroupID, amber_or_red_KRI_groups)
 
   if (lSetup$GroupLevel == "Site") {
     group_type <- "sites"
+    group_count <- lStudy$SiteCount
   } else if (lSetup$GroupLevel == "Country") {
     group_type <- "countries"
+    group_count <- lStudy$CountryCount
   }
 
   glue("
-        <div style = 'margin-top: 1em;'>As of {lSetup$SnapshotDate}, {lSetup$StudyID} has {as.numeric(lStudy$ParticipantCount)} participants enrolled across {lStudy$SiteCount} {group_type}. {length(red_KRI_groups)} Site-KRI combinations have been flagged across {length(unique(red_KRI_groups))} {group_type} as shown in the Study Overview Table above.</div>
+        <div style = 'margin-top: 1em;'>As of {lSetup$SnapshotDate}, {lSetup$StudyID} has {as.numeric(lStudy$ParticipantCount)} participants enrolled across {group_count} {group_type}. {length(amber_or_red_KRI_groups)} {lSetup$GroupLevel}-KRI combinations have been flagged across {length(unique(amber_or_red_KRI_groups))} {group_type} as shown in the Study Overview Table above.</div>
        - <div>{length(unique(red_KRI_groups))} {group_type} have at least one red KRI</div>
        - <div>{length(unique(amber_or_red_KRI_groups))} {group_type} have at least one red or amber KRI</div>
        - <div>{length(unique(no_alert_groups))} {group_type} have neither red nor amber KRIS and are not shown</div>") %>% cat()

--- a/R/Report_Setup.R
+++ b/R/Report_Setup.R
@@ -44,6 +44,10 @@ Report_Setup <- function(dfGroups = NULL, dfMetrics = NULL, dfResults = NULL) {
     pivot_wider(names_from = "Param", values_from = "Value") %>%
     as.list()
 
+  if( output$GroupLevel == "Country") {
+    output$lStudy$CountryCount <- length(unique(dfResults$GroupID)) %>% as.character()
+  }
+
   output$StudyID <- dfGroups %>%
     filter(.data$GroupLevel == 'Study') %>%
     pull('GroupID') %>%

--- a/tests/testthat/_snaps/Report_MetricTable.md
+++ b/tests/testthat/_snaps/Report_MetricTable.md
@@ -4,5 +4,10 @@
       x <- Report_MetricTable(reportingResults_filt, reportingGroups)
       str(x, max.level = 2)
     Output
-       chr "Nothing flagged for this KRI."
+      List of 3
+       $ name    : chr "p"
+       $ attribs : Named list()
+       $ children:List of 1
+        ..$ : chr "Nothing flagged for this KRI."
+       - attr(*, "class")= chr "shiny.tag"
 

--- a/tests/testthat/test-Report_MetricTable.R
+++ b/tests/testthat/test-Report_MetricTable.R
@@ -3,7 +3,7 @@ test_that("Empty data frames return default message", {
   dfGroups_empty <- reportingGroups[-c(1:nrow(reportingGroups)), ]
   expect_equal(
     Report_MetricTable(dfResults_empty, dfGroups_empty),
-    "Nothing flagged for this KRI."
+    htmltools::tags$p("Nothing flagged for this KRI.")
   )
 })
 
@@ -16,7 +16,7 @@ test_that("Default message when nothing flagged", {
   dfGroups <- reportingGroups
   expect_equal(
     Report_MetricTable(dfResults, dfGroups),
-    "Nothing flagged for this KRI."
+    htmltools::tags$p("Nothing flagged for this KRI.")
   )
 })
 
@@ -56,7 +56,7 @@ test_that("Runs with just results with NULL group argument", {
 })
 
 test_that("Output is expected object", {
-  zero_flags <- c("0X003", "0x039")
+  zero_flags <- c("0X003", "0X039")
   red_flags <- c("0X113", "0X025")
   amber_flags <- c("0X119", "0X046")
 

--- a/tests/testthat/test-Report_OverviewText.R
+++ b/tests/testthat/test-Report_OverviewText.R
@@ -11,6 +11,7 @@ test_that("It handles different lSetup group values correctly", {
   )
 
   lSetup$GroupLevel <- "Country"
+  lStudy$CountryCount <- "3"
   expect_output(
     Report_OverviewText(lSetup, reportingResults, lStudy),
     "countries"
@@ -63,5 +64,6 @@ test_that("Handles different flag configurations", {
 
   expect_output(Report_OverviewText(lSetup, dfSummary, lStudy), "2 sites have at least one red KRI")
   expect_output(Report_OverviewText(lSetup, dfSummary, lStudy), "3 sites have at least one red or amber KRI")
-  expect_output(Report_OverviewText(lSetup, dfSummary, lStudy), "1 sites have neither red nor amber KRIS and are not shown")
+  expect_output(Report_OverviewText(lSetup, dfSummary, lStudy), "0 sites have neither red nor amber KRIS and are not shown")
 })
+


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Update Report_OverviewText and Report_Setup to handle country overview text properly. also deals with two existing bugs that displayed only red flag counts in the description and calculated `no_alert_groups` incorrectly.

Previous text:
![image](https://github.com/user-attachments/assets/67351844-bd11-4e59-a7ed-d0ec6f0757a2)

Updated text:
![image](https://github.com/user-attachments/assets/6179c07c-d9a1-4ef5-abd2-849bc5d4711a)


## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX

