### PR TITLE
Update `Metrics.yaml` to not generate `lWorkflows` within steps

### DIFF
--- a/inst/examples/3_ReportingWorkflow.R
+++ b/inst/examples/3_ReportingWorkflow.R
@@ -55,7 +55,8 @@ analyzed <- RunWorkflows(metrics_wf, mapped)
 
 # Step 3 - Create Reporting Layer - create reports using metrics data
 reporting_wf <- MakeWorkflowList(strPath = "workflow/3_reporting")
-reporting <- RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed, lWorkflows = metrics_wf)))
+reporting <- RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed,
+                                                       lWorkflows = metrics_wf)))
 
 # Step 4 - Create KRI Reports - create KRI report using reporting data
 module_wf <- MakeWorkflowList(strPath = "workflow/4_modules")
@@ -76,7 +77,8 @@ analyzed <- RunWorkflows(metrics_wf, mapped)
 
 # Step 3 - Create Reporting Layer - create reports using metrics data
 reporting_wf <- MakeWorkflowList(strPath = "workflow/3_reporting")
-reporting <- RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed, lWorkflows = metrics_wf)))
+reporting <- RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed,
+                                                       lWorkflows = metrics_wf)))
 
 # Step 4 - Create KRI Report - create KRI report using reporting data
 module_wf <- MakeWorkflowList(strPath = "workflow/4_modules")

--- a/inst/workflow/3_reporting/Metrics.yaml
+++ b/inst/workflow/3_reporting/Metrics.yaml
@@ -4,6 +4,7 @@ meta:
   Description: Reporting Metrics Data
   Priority: 1
 steps:
+  # lWorkflows is a named list of metric workflows.
   - output: Reporting_Metrics
     name: MakeMetric
     params:

--- a/inst/workflow/3_reporting/Metrics.yaml
+++ b/inst/workflow/3_reporting/Metrics.yaml
@@ -1,13 +1,9 @@
 meta:
   Type: Reporting
   ID: Metrics
-  Description: Reporting Metrics Data 
+  Description: Reporting Metrics Data
   Priority: 1
 steps:
-  - output: lWorkflows
-    name: MakeWorkflowList
-    params:
-      strPackage: gsm
   - output: Reporting_Metrics
     name: MakeMetric
     params:

--- a/tests/testthat/_snaps/util-MakeWorkflowList.md
+++ b/tests/testthat/_snaps/util-MakeWorkflowList.md
@@ -4196,26 +4196,13 @@
       $Metrics
       $Metrics[[1]]
       $Metrics[[1]]$output
-      [1] "lWorkflows"
-      
-      $Metrics[[1]]$name
-      [1] "MakeWorkflowList"
-      
-      $Metrics[[1]]$params
-      $Metrics[[1]]$params$strPackage
-      [1] "gsm"
-      
-      
-      
-      $Metrics[[2]]
-      $Metrics[[2]]$output
       [1] "Reporting_Metrics"
       
-      $Metrics[[2]]$name
+      $Metrics[[1]]$name
       [1] "MakeMetric"
       
-      $Metrics[[2]]$params
-      $Metrics[[2]]$params$lWorkflows
+      $Metrics[[1]]$params
+      $Metrics[[1]]$params$lWorkflows
       [1] "lWorkflows"
       
       


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
`lWorkflows` should be based on the current module/study being run, not always just the `gsm` workflows. This simply updates the flow to take an `lWorkflows` argument in the `lData` list in `RunWorkflows()` to run Metrics.yaml properly. 

Note: `lWorkflows` was already being fed into `RunWorkflows()` in this way, so this is not an update to process, just a simplification.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1929 

