### PR TITLE
Add thresholds back into barcharts

### DIFF
--- a/R/Visualize_Metric.R
+++ b/R/Visualize_Metric.R
@@ -135,6 +135,7 @@ Visualize_Metric <- function(
       dfResults = dfResults_latest,
       lMetric = lMetric,
       dfGroups = dfGroups,
+      vThreshold = vThreshold,
       strOutcome = "Metric",
       bDebug = bDebug
     )
@@ -143,6 +144,7 @@ Visualize_Metric <- function(
       dfResults = dfResults_latest,
       lMetric = lMetric,
       dfGroups = dfGroups,
+      vThreshold = vThreshold,
       strOutcome = "Score",
       bDebug = bDebug
     )


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
add `vThreshold` argument back into `Widget_BarChart()` call in `Visualize_Metric()`

see below: 
![image](https://github.com/user-attachments/assets/ec60ac6a-4104-4d42-a750-cee2fdd30466)


## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1958

