### PR TITLE
fix issue in `RunQuery` related to incomplete column spec

### DIFF
--- a/R/RunQuery.R
+++ b/R/RunQuery.R
@@ -42,18 +42,21 @@ RunQuery <- function(strQuery, df, bUseSchema = FALSE, lColumnMapping = NULL) {
     stop("if use_schema = TRUE, you must provide lColumnMapping spec")
   }
 
-  #use `source_col` for `source` if using mapping and it hasn't gone through ApplySpec()
-  if (bUseSchema && any(map_lgl(lColumnMapping, \(x) is.null(x$source)))) {
+  # Enforce data structure of schema.
+  if (bUseSchema) {
     lColumnMapping <- lColumnMapping %>%
-        imap(
-          function(spec, name) {
-            mapping <- list(target = name)
-            mapping$source <- spec$source_col %||% name
-            mapping$type <- spec$type %||% NULL
-            return(mapping)
-          })
-  }
+      imap(function(spec, name) {
+        mapping <- list(target = name)
 
+        # use `source_col` for `source` if using mapping and it hasn't gone through ApplySpec()
+        mapping$source <- spec$source %||% spec$source_col %||% name
+
+        # NULL type breaks things below
+        mapping$type <- spec$type %||% ''
+
+        return(mapping)
+      })
+  }
 
   # Set up the connection and table names if passing in duckdb lazy table
   if (inherits(df, "tbl_dbi")) {

--- a/tests/testthat/test_RunQuery.R
+++ b/tests/testthat/test_RunQuery.R
@@ -116,3 +116,25 @@ test_that("RunQuery applies schema appropriately", {
   expect_equal(class(result$Age), "integer")
   expect_equal(class(result$Name), "character")
 })
+
+test_that("RunQuery applies incomplete schema appropriately", {
+  # Create a sample data frame
+  df <- data.frame(
+    Name = c("John", "Jane", "Bob"),
+    Age = c(25, 30, 35),
+    Salary = c(50000, 60000, "70000"),
+    Birthday = c("1990-01-01", "1987-02-02", "1985-03-03")
+  )
+  lColumnMapping <- list(
+    emaN = list(
+      source = 'Name'
+    )
+  )
+
+  # Define the query and mapping
+  query <- "SELECT Name as emaN FROM df WHERE Name LIKE '%o%'"
+
+  # Call the RunQuery function and expect no error
+  expect_no_error(result <- RunQuery(query, df, bUseSchema = T, lColumnMapping = lColumnMapping))
+  expect_equal(class(result$emaN), "character")
+})


### PR DESCRIPTION
## Overview
An issue popped up running the `Groups` workflow where `RunQuery` couldn't find a `type` attribute on a column spec.  This PR enforces the column spec data structure.

## Test Notes/Sample Code
```
  # Create a sample data frame
  df <- data.frame(
    Name = c("John", "Jane", "Bob")
  )
  lColumnMapping <- list(
    emaN = list(
      source = 'Name'
    )
  )

  # Define the query and mapping
  query <- "SELECT Name as emaN FROM df WHERE Name LIKE '%o%'"

  # Call the RunQuery function and expect no error
  expect_no_error(result <- RunQuery(query, df, bUseSchema = T, lColumnMapping = lColumnMapping))
  expect_equal(class(result$emaN), "character")
```

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #XXX

