### PR TITLE
Fix #1992- always return function in namespace util

### DIFF
--- a/R/util-func-namespace.R
+++ b/R/util-func-namespace.R
@@ -4,7 +4,7 @@
 #'
 #' This function looks to see if a strFunction is namespaced and looks it up
 #' allowing the do.call in run step to process correctly
-#' this will either return a function, or the original string if not namespaced
+#' this will return a function.
 #'
 #' @param strFunction the function to be called
 #' @export

--- a/R/util-func-namespace.R
+++ b/R/util-func-namespace.R
@@ -3,8 +3,8 @@
 #' `r lifecycle::badge("experimental")`
 #'
 #' This function looks to see if a strFunction is namespaced and looks it up
-#' allowing the do.call in run step to process correctly
-#' this will return a function.
+#' allowing the do.call in run step to process correctly.
+#' This will return a function.
 #'
 #' @param strFunction the function to be called
 #' @export
@@ -21,7 +21,5 @@ GetStrFunctionIfNamespaced <- function(strFunction) {
     fn <- fn_pieces[[2]]
     return(rlang::as_function(fn, env = getNamespace(pkg)))
   }
-  else {
-    return(rlang::as_function(strFunction))
-  }
+  return(rlang::as_function(strFunction))
 }

--- a/R/util-func-namespace.R
+++ b/R/util-func-namespace.R
@@ -21,5 +21,7 @@ GetStrFunctionIfNamespaced <- function(strFunction) {
     fn <- fn_pieces[[2]]
     return(rlang::as_function(fn, env = getNamespace(pkg)))
   }
-  return(strFunction)
+  else {
+    return(rlang::as_function(strFunction))
+  }
 }

--- a/man/GetStrFunctionIfNamespaced.Rd
+++ b/man/GetStrFunctionIfNamespaced.Rd
@@ -14,7 +14,7 @@ GetStrFunctionIfNamespaced(strFunction)
 
 This function looks to see if a strFunction is namespaced and looks it up
 allowing the do.call in run step to process correctly
-this will either return a function, or the original string if not namespaced
+this will return a function.
 }
 \examples{
 fn <- GetStrFunctionIfNamespaced("dplyr::glimpse")

--- a/man/GetStrFunctionIfNamespaced.Rd
+++ b/man/GetStrFunctionIfNamespaced.Rd
@@ -13,8 +13,8 @@ GetStrFunctionIfNamespaced(strFunction)
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
 This function looks to see if a strFunction is namespaced and looks it up
-allowing the do.call in run step to process correctly
-this will return a function.
+allowing the do.call in run step to process correctly.
+This will return a function.
 }
 \examples{
 fn <- GetStrFunctionIfNamespaced("dplyr::glimpse")


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Simple fix to always have the same output class (function) in the `GetStrFunctionInNamespace()`

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1992

