### PR TITLE
Add button to show/hide report table of contents

### DIFF
--- a/R/Analyze_NormalApprox.R
+++ b/R/Analyze_NormalApprox.R
@@ -33,8 +33,8 @@
 #' @export
 
 Analyze_NormalApprox <- function(
-  dfTransformed,
-  strType = "binary"
+    dfTransformed,
+    strType = "binary"
 ) {
   stop_if(cnd = !is.data.frame(dfTransformed), message = "dfTransformed is not a data.frame")
   stop_if(
@@ -50,15 +50,15 @@ Analyze_NormalApprox <- function(
       mutate(
         vMu = sum(.data$Numerator) / sum(.data$Denominator),
         z_0 = ifelse(.data$vMu == 0 | .data$vMu == 1,
-          0,
-          (.data$Metric - .data$vMu) /
-            sqrt(.data$vMu * (1 - .data$vMu) / .data$Denominator)
+                     0,
+                     (.data$Metric - .data$vMu) /
+                       sqrt(.data$vMu * (1 - .data$vMu) / .data$Denominator)
         ),
         phi = mean(.data$z_0^2),
         z_i = ifelse(.data$vMu == 0 | .data$vMu == 1 | .data$phi == 0,
-          0,
-          (.data$Metric - .data$vMu) /
-            sqrt(.data$phi * .data$vMu * (1 - .data$vMu) / .data$Denominator)
+                     0,
+                     (.data$Metric - .data$vMu) /
+                       sqrt(.data$phi * .data$vMu * (1 - .data$vMu) / .data$Denominator)
         )
       )
   } else if (strType == "rate") {
@@ -66,15 +66,15 @@ Analyze_NormalApprox <- function(
       mutate(
         vMu = sum(.data$Numerator) / sum(.data$Denominator),
         z_0 = ifelse(.data$vMu == 0,
-          0,
-          (.data$Metric - .data$vMu) /
-            sqrt(.data$vMu / .data$Denominator)
+                     0,
+                     (.data$Metric - .data$vMu) /
+                       sqrt(.data$vMu / .data$Denominator)
         ),
         phi = mean(.data$z_0^2),
         z_i = ifelse(.data$vMu == 0 | .data$phi == 0,
-          0,
-          (.data$Metric - .data$vMu) /
-            sqrt(.data$phi * .data$vMu / .data$Denominator)
+                     0,
+                     (.data$Metric - .data$vMu) /
+                       sqrt(.data$phi * .data$vMu / .data$Denominator)
         )
       )
   }

--- a/inst/examples/3_ReportingWorkflow.R
+++ b/inst/examples/3_ReportingWorkflow.R
@@ -53,7 +53,7 @@ mappings_wf <- MakeWorkflowList(strPath = "workflow/1_mappings")
 mapped <- RunWorkflows(mappings_wf, lRaw)
 
 # Step 2 - Create Metrics - calculate metrics using mapped data
-metrics_wf <- MakeWorkflowList(strPath = "workflow/2_metrics")
+metrics_wf <- MakeWorkflowList(strPath = "workflow/2_metrics", strNames = "kri")
 analyzed <- RunWorkflows(metrics_wf, mapped)
 
 # Step 3 - Create Reporting Layer - create reports using metrics data

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -21,6 +21,7 @@ knitr::opts_chunk$set(warning = FALSE, message = FALSE)
 ```{r, results='asis', echo=FALSE, message=FALSE, warning=FALSE}
 library(gsm)
 library(gt)
+library(htmltools)
 
 setup <- Report_Setup(
   dfGroups =  params$dfGroups, 
@@ -28,7 +29,32 @@ setup <- Report_Setup(
   dfResults = params$dfResults
 )
 
+tags$script(
+  'document.addEventListener("load", function() {
+  console.log("JavaScript is loaded and running!");
+  // Create the toggle button
+  const button = document.createElement("button");
+  button.id = "toc-toggle";
+  button.textContent = "Toggle TOC";
+  document.body.appendChild(button);
+
+  // Get the TOC element
+  const toc = document.querySelector(".tocify");
+  console.log(toc);
+
+  // Add event listener to toggle button
+  button.addEventListener("click", function() {
+    if (toc.classList.contains("hidden")) {
+      toc.classList.remove("hidden");
+    } else {
+      toc.classList.add("hidden");
+    }
+  });
+});'
+)
+
 ```
+
 
 
 ---

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -21,7 +21,6 @@ knitr::opts_chunk$set(warning = FALSE, message = FALSE)
 ```{r, results='asis', echo=FALSE, message=FALSE, warning=FALSE}
 library(gsm)
 library(gt)
-library(htmltools)
 
 setup <- Report_Setup(
   dfGroups =  params$dfGroups, 
@@ -29,34 +28,7 @@ setup <- Report_Setup(
   dfResults = params$dfResults
 )
 
-tags$script(
-  'document.addEventListener("load", function() {
-  console.log("JavaScript is loaded and running!");
-  // Create the toggle button
-  const button = document.createElement("button");
-  button.id = "toc-toggle";
-  button.textContent = "Toggle TOC";
-  document.body.appendChild(button);
-
-  // Get the TOC element
-  const toc = document.querySelector(".tocify");
-  console.log(toc);
-
-  // Add event listener to toggle button
-  button.addEventListener("click", function() {
-    if (toc.classList.contains("hidden")) {
-      toc.classList.remove("hidden");
-    } else {
-      toc.classList.add("hidden");
-    }
-  });
-});'
-)
-
 ```
-
-
-
 ---
 title: "`r setup$GroupLevel` KRI Overview"
 subtitle: "Study: `r setup$StudyLabel`"
@@ -195,4 +167,70 @@ dropdown_drag <- system.file('report', 'lib', 'dragOverallGroupDropdown.js', pac
 ```
 
 ```{js, file={dropdown_drag}, echo=FALSE}
+```
+
+```{js}
+document.addEventListener("DOMContentLoaded", function () {
+  console.log("Document loaded. Initializing TOC toggle functionality.");
+ 
+  // Create the toggle button
+  const button = document.createElement("div");
+  button.id = "toc-toggle";
+  button.style.position = "fixed";
+  button.style.top = "10px";
+  button.style.left = "10px";
+  button.style.zIndex = "1000";
+  button.style.width = "40px";
+  button.style.height = "25px";
+  button.style.display = "flex";
+  button.style.flexDirection = "column";
+  button.style.justifyContent = "space-around";
+  button.style.alignItems = "center";
+  button.style.backgroundColor = "transparent";
+  button.style.border = "none";
+  button.style.cursor = "pointer";
+ 
+  // Create the hamburger lines
+  for (let i = 0; i < 3; i++) {
+    const line = document.createElement("div");
+    line.style.width = "100%";
+    line.style.height = "4px";
+    line.style.backgroundColor = "gray";
+    line.style.borderRadius = "2px";
+    button.appendChild(line);
+  }
+ 
+  document.body.appendChild(button);
+  console.log("Hamburger toggle button created and added to the page.");
+ 
+  // Select the TOC and main content elements
+  const toc = document.querySelector("#TOC");
+  const mainContent = document.querySelector(".col-xs-12.col-sm-8.col-md-9");
+ 
+  // Add click event to toggle TOC visibility and adjust content width
+  button.addEventListener("click", function () {
+    console.log("Toggle button clicked.");
+    toc.classList.toggle("hidden");
+ 
+    if (toc.classList.contains("hidden")) {
+      console.log("TOC is now hidden. Expanding main content.");
+      mainContent.classList.remove("col-sm-8", "col-md-9");
+      mainContent.classList.add("col-sm-12", "col-md-12");
+    } else {
+      console.log("TOC is now visible. Restoring main content width.");
+      mainContent.classList.remove("col-sm-12", "col-md-12");
+      mainContent.classList.add("col-sm-8", "col-md-9");
+    }
+  });
+ 
+  // Add CSS for the 'hidden' class dynamically
+  const style = document.createElement("style");
+  style.innerHTML = `
+    #TOC.hidden {
+      display: none;
+    }
+  `;
+  document.head.appendChild(style);
+});
+ 
 ```

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -161,6 +161,7 @@ params$dfMetrics %>%
 ```{r echo=FALSE}
 group_dropdown <- system.file('report', 'lib', 'overallGroupDropdown.js', package = "gsm")
 dropdown_drag <- system.file('report', 'lib', 'dragOverallGroupDropdown.js', package = "gsm")
+toggle_toc <- system.file('report', 'lib', 'lib/toggleTOC.js', package = "gsm")
 ```
 
 ```{js, file={group_dropdown}, echo=FALSE}
@@ -169,68 +170,5 @@ dropdown_drag <- system.file('report', 'lib', 'dragOverallGroupDropdown.js', pac
 ```{js, file={dropdown_drag}, echo=FALSE}
 ```
 
-```{js}
-document.addEventListener("DOMContentLoaded", function () {
-  console.log("Document loaded. Initializing TOC toggle functionality.");
- 
-  // Create the toggle button
-  const button = document.createElement("div");
-  button.id = "toc-toggle";
-  button.style.position = "fixed";
-  button.style.top = "10px";
-  button.style.left = "10px";
-  button.style.zIndex = "1000";
-  button.style.width = "40px";
-  button.style.height = "25px";
-  button.style.display = "flex";
-  button.style.flexDirection = "column";
-  button.style.justifyContent = "space-around";
-  button.style.alignItems = "center";
-  button.style.backgroundColor = "transparent";
-  button.style.border = "none";
-  button.style.cursor = "pointer";
- 
-  // Create the hamburger lines
-  for (let i = 0; i < 3; i++) {
-    const line = document.createElement("div");
-    line.style.width = "100%";
-    line.style.height = "4px";
-    line.style.backgroundColor = "gray";
-    line.style.borderRadius = "2px";
-    button.appendChild(line);
-  }
- 
-  document.body.appendChild(button);
-  console.log("Hamburger toggle button created and added to the page.");
- 
-  // Select the TOC and main content elements
-  const toc = document.querySelector("#TOC");
-  const mainContent = document.querySelector(".col-xs-12.col-sm-8.col-md-9");
- 
-  // Add click event to toggle TOC visibility and adjust content width
-  button.addEventListener("click", function () {
-    console.log("Toggle button clicked.");
-    toc.classList.toggle("hidden");
- 
-    if (toc.classList.contains("hidden")) {
-      console.log("TOC is now hidden. Expanding main content.");
-      mainContent.classList.remove("col-sm-8", "col-md-9");
-      mainContent.classList.add("col-sm-12", "col-md-12");
-    } else {
-      console.log("TOC is now visible. Restoring main content width.");
-      mainContent.classList.remove("col-sm-12", "col-md-12");
-      mainContent.classList.add("col-sm-8", "col-md-9");
-    }
-  });
- 
-  // Add CSS for the 'hidden' class dynamically
-  const style = document.createElement("style");
-  style.innerHTML = `
-    #TOC.hidden {
-      display: none;
-    }
-  `;
-  document.head.appendChild(style);
-});
- 
+```{js, file={toggle_toc}, echo=FALSE}
 ```

--- a/inst/report/Report_KRI.Rmd
+++ b/inst/report/Report_KRI.Rmd
@@ -161,7 +161,7 @@ params$dfMetrics %>%
 ```{r echo=FALSE}
 group_dropdown <- system.file('report', 'lib', 'overallGroupDropdown.js', package = "gsm")
 dropdown_drag <- system.file('report', 'lib', 'dragOverallGroupDropdown.js', package = "gsm")
-toggle_toc <- system.file('report', 'lib', 'lib/toggleTOC.js', package = "gsm")
+toggle_toc <- system.file('report', 'lib', 'toggleTOC.js', package = "gsm")
 ```
 
 ```{js, file={group_dropdown}, echo=FALSE}

--- a/inst/report/lib/toggleTOC.js
+++ b/inst/report/lib/toggleTOC.js
@@ -1,4 +1,65 @@
-document.addEventListener("load", function() {
+document.addEventListener("DOMContentLoaded", function () {
+  console.log("Document loaded. Initializing TOC toggle functionality.");
+
+  // Create the toggle button
+  const button = document.createElement("div");
+  button.id = "toc-toggle";
+  button.style.position = "fixed";
+  button.style.top = "10px";
+  button.style.left = "10px";
+  button.style.zIndex = "1000";
+  button.style.width = "40px";
+  button.style.height = "25px";
+  button.style.display = "flex";
+  button.style.flexDirection = "column";
+  button.style.justifyContent = "space-around";
+  button.style.alignItems = "center";
+  button.style.backgroundColor = "transparent";
+  button.style.border = "none";
+  button.style.cursor = "pointer";
+
+  // Create the hamburger lines
+  for (let i = 0; i < 3; i++) {
+    const line = document.createElement("div");
+    line.style.width = "100%";
+    line.style.height = "4px";
+    line.style.backgroundColor = "gray";
+    line.style.borderRadius = "2px";
+    button.appendChild(line);
+  }
+
+  document.body.appendChild(button);
+  console.log("Hamburger toggle button created and added to the page.");
+
+  // Select the TOC and main content elements
+  const toc = document.querySelector("#TOC");
+  const mainContent = document.querySelector(".col-xs-12.col-sm-8.col-md-9");
+
+  // Add click event to toggle TOC visibility and adjust content width
+  button.addEventListener("click", function () {
+    console.log("Toggle button clicked.");
+    toc.classList.toggle("hidden");
+
+    if (toc.classList.contains("hidden")) {
+      console.log("TOC is now hidden. Expanding main content.");
+      mainContent.classList.remove("col-sm-8", "col-md-9");
+      mainContent.classList.add("col-sm-12", "col-md-12");
+    } else {
+      console.log("TOC is now visible. Restoring main content width.");
+      mainContent.classList.remove("col-sm-12", "col-md-12");
+      mainContent.classList.add("col-sm-8", "col-md-9");
+    }
+  });
+
+  // Add CSS for the 'hidden' class dynamically
+  const style = document.createElement("style");
+  style.innerHTML = `
+    #TOC.hidden {
+      display: none;
+    }
+  `;
+  document.head.appendChild(style);
+});document.addEventListener("load", function() {
   console.log("JavaScript is loaded and running!");
   // Create the toggle button
   const button = document.createElement("button");

--- a/inst/report/lib/toggleTOC.js
+++ b/inst/report/lib/toggleTOC.js
@@ -1,0 +1,20 @@
+document.addEventListener("load", function() {
+  console.log("JavaScript is loaded and running!");
+  // Create the toggle button
+  const button = document.createElement("button");
+  button.id = "toc-toggle";
+  button.textContent = "Toggle TOC";
+  document.body.appendChild(button);
+
+  // Get the TOC element
+  const toc = document.querySelector("#TOC");
+
+  // Add event listener to toggle button
+  button.addEventListener("click", function() {
+    if (toc.classList.contains("hidden")) {
+      toc.classList.remove("hidden");
+    } else {
+      toc.classList.add("hidden");
+    }
+  });
+});

--- a/inst/report/lib/toggleTOC.js
+++ b/inst/report/lib/toggleTOC.js
@@ -2,34 +2,37 @@ document.addEventListener("DOMContentLoaded", function () {
   console.log("Document loaded. Initializing TOC toggle functionality.");
 
   // Create the toggle button
-  const button = document.createElement("div");
+  const button = document.createElement("button");
   button.id = "toc-toggle";
   button.style.position = "fixed";
   button.style.top = "10px";
   button.style.left = "10px";
   button.style.zIndex = "1000";
-  button.style.width = "40px";
+  button.style.width = "80px";
   button.style.height = "25px";
   button.style.display = "flex";
   button.style.flexDirection = "column";
   button.style.justifyContent = "space-around";
   button.style.alignItems = "center";
   button.style.backgroundColor = "transparent";
+  button.style.color = '#9D9D9D';
   button.style.border = "none";
   button.style.cursor = "pointer";
+  button.style.borderRadius = "10px";
+  button.innerHTML = 'Hide TOC';
 
   // Create the hamburger lines
-  for (let i = 0; i < 3; i++) {
-    const line = document.createElement("div");
-    line.style.width = "100%";
-    line.style.height = "4px";
-    line.style.backgroundColor = "gray";
-    line.style.borderRadius = "2px";
-    button.appendChild(line);
-  }
+  // for (let i = 0; i < 3; i++) {
+  //   const line = document.createElement("div");
+  //   line.style.width = "100%";
+  //   line.style.height = "4px";
+  //   line.style.backgroundColor = "gray";
+  //   line.style.borderRadius = "2px";
+  //   button.appendChild(line);
+  // }
 
   document.body.appendChild(button);
-  console.log("Hamburger toggle button created and added to the page.");
+  console.log("TOC toggle button created and added to the page.");
 
   // Select the TOC and main content elements
   const toc = document.querySelector("#TOC");
@@ -44,10 +47,16 @@ document.addEventListener("DOMContentLoaded", function () {
       console.log("TOC is now hidden. Expanding main content.");
       mainContent.classList.remove("col-sm-8", "col-md-9");
       mainContent.classList.add("col-sm-12", "col-md-12");
+      button.innerHTML = 'Show TOC';
+      button.style.backgroundColor = '#9D9D9D';
+      button.style.color = 'white';
     } else {
       console.log("TOC is now visible. Restoring main content width.");
       mainContent.classList.remove("col-sm-12", "col-md-12");
       mainContent.classList.add("col-sm-8", "col-md-9");
+      button.innerHTML = 'Hide TOC';
+      button.style.backgroundColor = 'transparent';
+      button.style.color = '#9D9D9D';
     }
   });
 

--- a/inst/report/styles.css
+++ b/inst/report/styles.css
@@ -121,24 +121,6 @@ table.dataTable.compact thead th, table.dataTable.compact thead td {
   display: none;
 }
 
-/* Styling for the TOC button */
-#toc-toggle {
-  position: fixed;
-  top: 10px;
-  left: 10px;
-  z-index: 1000;
-  background-color: #007bff;
-  color: white;
-  padding: 5px 10px;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-}
-
-#toc-toggle:hover {
-  background-color: #0056b3;
-}
-
 /* Adjusting the TOC position and transition */
 #TOC {
   transition: transform 0.3s ease-in-out;

--- a/inst/report/styles.css
+++ b/inst/report/styles.css
@@ -121,6 +121,32 @@ table.dataTable.compact thead th, table.dataTable.compact thead td {
   display: none;
 }
 
+/* Styling for the TOC button */
+#toc-toggle {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 1000;
+  background-color: #007bff;
+  color: white;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+#toc-toggle:hover {
+  background-color: #0056b3;
+}
+
+/* Adjusting the TOC position and transition */
+#TOC {
+  transition: transform 0.3s ease-in-out;
+}
+
+#TOC.hidden {
+  transform: translateX(-300px); /* Hide TOC off the screen */
+}
 
 /* Group summary table -- change cursor to cue to user that tooltip is available */
 td[title] {


### PR DESCRIPTION
## Overview
<!--- What was done in the source branch -->
<!--- (i.e. bugfixes, feature additions, etc.) -->
Per CM team request, adding a hamburger button to allow the user to hide the table of contents in the kri report. 

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->
We might want to think about adjusting the default width of the report to be a percentage of the screen instead of a fixed width, but not sure if that is needed at the moment.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #1963

