### PR TITLE
Remove glossary.

### DIFF
--- a/R/Analyze_Fisher.R
+++ b/R/Analyze_Fisher.R
@@ -1,9 +1,8 @@
 #' Fisher's Exact Test Analysis.
 #'
-#' @description
-#' `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("stable")`
 #'
-#' Analyzes count data using the Fisher's exact test.
+#'   Analyzes count data using the Fisher's exact test.
 #'
 #'   More information can be found in [The Fisher's Exact Method
 #'   Section](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-fishers-exact-method)
@@ -23,8 +22,12 @@
 #'   analysis are flagged by default. The significance level was set at a common
 #'   choice.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Rate")`
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Rate()].
 #' @param strOutcome `character` required, name of column in `dfTransformed`
 #'   dataset to perform Fisher's exact test on. Default is "Numerator".
 #'

--- a/R/Analyze_Identity.R
+++ b/R/Analyze_Identity.R
@@ -1,18 +1,24 @@
 #' Identity Analysis.
 #'
-#' @description
-#' `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("stable")`
 #'
-#' Used in the data pipeline between `Transform` and `Flag` to rename KRI and Score columns.
+#'   Used in the data pipeline between `Transform` and `Flag` to rename KRI and
+#'   Score columns.
 #'
-#' More information can be found in [The Identity Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-identity-method)
-#' of the KRI Method vignette.
+#'   More information can be found in [The Identity
+#'   Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-identity-method)
+#'   of the KRI Method vignette.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Count")`
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Count()].
 #' @param strValueCol `character` Name of column that will be copied as `Score`
 #'
-#' @return `data.frame` with one row per site with columns: GroupID, TotalCount, Metric, and Score.
+#' @return `data.frame` with one row per site with columns: GroupID, TotalCount,
+#'   Metric, and Score.
 #'
 #' @examples
 #' dfTransformed <- Transform_Count(analyticsInput, strCountCol = "Numerator")

--- a/R/Analyze_NormalApprox.R
+++ b/R/Analyze_NormalApprox.R
@@ -1,25 +1,32 @@
 #' Funnel Plot Analysis with Normal Approximation for Binary and Rate Outcomes.
 #'
-#' @description
-#' `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("stable")`
 #'
-#' Creates analysis results data for percentage/rate data using funnel plot method with normal approximation.
+#' Creates analysis results data for percentage/rate data using funnel plot
+#' method with normal approximation.
 #'
-#' More information can be found in [The Normal Approximation Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-normal-approximation-method)
+#' More information can be found in [The Normal Approximation
+#' Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-normal-approximation-method)
 #' of the KRI Method vignette.
 #'
-#' @section Statistical Methods:
-#' This function applies funnel plots using asymptotic limits based on the normal approximation of a binomial distribution for
-#' the binary outcome, or normal approximation of a Poisson distribution for the rate outcome with volume (the sample sizes
-#' or total exposure of the sites) to assess data quality and safety.
+#' @section Statistical Methods: This function applies funnel plots using
+#'   asymptotic limits based on the normal approximation of a binomial
+#'   distribution for the binary outcome, or normal approximation of a Poisson
+#'   distribution for the rate outcome with volume (the sample sizes or total
+#'   exposure of the sites) to assess data quality and safety.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Rate")`
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Rate()].
 #' @param strType `character` Statistical outcome type. Valid values:
 #'   - `"binary"` (default)
 #'   - `"rate"`
 #'
-#' @return `data.frame` with one row per site with columns: GroupID, Numerator, Denominator, Metric, OverallMetric, Factor, and Score.
+#' @return `data.frame` with one row per site with columns: GroupID, Numerator,
+#'   Denominator, Metric, OverallMetric, Factor, and Score.
 #'
 #' @examples
 #' # Binary

--- a/R/Analyze_NormalApprox_PredictBounds.R
+++ b/R/Analyze_NormalApprox_PredictBounds.R
@@ -1,27 +1,33 @@
 #' Funnel Plot Analysis with Normal Approximation - Predicted Boundaries.
 #'
-#' @description
-#' `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("stable")`
 #'
-#' Applies a funnel plot analysis with normal approximation to site-level data, and then calculates predicted
-#' percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values.
-#'
-#' @section Statistical Methods:
-#' This function applies a funnel plot analysis with normal approximation to site-level data and then calculates
-#' predicted percentages/rates and upper- and lower- bounds (funnels) based on the standard deviation from the mean
+#' Applies a funnel plot analysis with normal approximation to site-level data,
+#' and then calculates predicted percentages/rates and upper- and lower-bounds
 #' across the full range of sample sizes/total exposure values.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Rate")`
-#' @param vThreshold `numeric` upper and lower boundaries based on standard deviation. Should be identical to
-#' the thresholds used in `*_Assess()` functions.
+#' @section Statistical Methods: This function applies a funnel plot analysis
+#'   with normal approximation to site-level data and then calculates predicted
+#'   percentages/rates and upper- and lower- bounds (funnels) based on the
+#'   standard deviation from the mean across the full range of sample
+#'   sizes/total exposure values.
+#'
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Rate()].
+#' @param vThreshold `numeric` upper and lower boundaries based on standard
+#'   deviation. Should be identical to the thresholds used in `*_Assess()`
+#'   functions.
 #' @param nStep `numeric` step size of imputed bounds.
 #' @param strType `character` Statistical method. Valid values:
 #'   - `"binary"` (default)
 #'   - `"rate"`
 #'
-#' @return `data.frame` containing predicted boundary values with upper and lower bounds across the
-#' range of observed values.
+#' @return `data.frame` containing predicted boundary values with upper and
+#'   lower bounds across the range of observed values.
 #'
 #' @examples
 #' # Binary

--- a/R/Analyze_Poisson.R
+++ b/R/Analyze_Poisson.R
@@ -2,22 +2,30 @@
 #'
 #' `r lifecycle::badge("stable")`
 #'
-#' @details
-#' Fits a Poisson model to site-level data and adds columns capturing Residual and Predicted Count for each site.
+#' @details Fits a Poisson model to site-level data and adds columns capturing
+#' Residual and Predicted Count for each site.
 #'
-#' More information can be found in [The Poisson Regression Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-poisson-regression-method)
+#' More information can be found in [The Poisson Regression
+#' Method](https://gilead-biostats.github.io/gsm/articles/KRI%20Method.html#the-poisson-regression-method)
 #' of the KRI Method vignette.
 #'
 #' @section Statistical Methods:
 #'
-#' This function fits a Poisson model to site-level data and then calculates residuals for each site.
-#' The Poisson model is run using standard methods in the `stats` package by fitting a `glm` model with family
-#' set to `poisson` using a "log" link. Site-level residuals are calculated using `stats::predict.glm` via `broom::augment`.
+#'   This function fits a Poisson model to site-level data and then calculates
+#'   residuals for each site. The Poisson model is run using standard methods in
+#'   the `stats` package by fitting a `glm` model with family set to `poisson`
+#'   using a "log" link. Site-level residuals are calculated using
+#'   `stats::predict.glm` via `broom::augment`.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Rate")`
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Rate()].
 #'
-#' @return `data.frame` with one row per site with columns: GroupID, Numerator, Denominator, Metric, Score, and PredictedCount.
+#' @return `data.frame` with one row per site with columns: GroupID, Numerator,
+#'   Denominator, Metric, Score, and PredictedCount.
 #'
 #' @examples
 #' dfTransformed <- Transform_Rate(analyticsInput)

--- a/R/Analyze_Poisson_PredictBounds.R
+++ b/R/Analyze_Poisson_PredictBounds.R
@@ -1,25 +1,30 @@
 #' Poisson Analysis - Predicted Boundaries.
 #'
-#' @description
-#' `r lifecycle::badge("stable")`
+#' @description `r lifecycle::badge("stable")`
 #'
-#' Fits a Poisson model to site-level data and then calculates predicted count values and upper- and
-#' lower- bounds for across the full range of exposure values.
+#' Fits a Poisson model to site-level data and then calculates predicted count
+#' values and upper- and lower- bounds for across the full range of exposure
+#' values.
 #'
-#' @section Statistical Methods:
-#' This function fits a Poisson model to site-level data and then calculates residuals for each
-#' site. The Poisson model is run using standard methods in the `stats` package by fitting a `glm`
-#' model with family set to `poisson` using a "log" link. Upper and lower boundary values are then
-#' calculated using the method described here TODO: Add link.
+#' @section Statistical Methods: This function fits a Poisson model to
+#'   site-level data and then calculates residuals for each site. The Poisson
+#'   model is run using standard methods in the `stats` package by fitting a
+#'   `glm` model with family set to `poisson` using a "log" link. Upper and
+#'   lower boundary values are then calculated using the method described here
+#'   TODO: Add link.
 #'
-#' @param dfTransformed `r gloss_param("dfTransformed")`
-#'   `r gloss_extra("dfTransformed_Rate")`
-#' @param vThreshold `numeric` upper and lower boundaries in residual space. Should be identical to
-#' the thresholds used AE_Assess().
+#' @param dfTransformed `data.frame` Transformed data for analysis. Data should
+#'   have one record per site with expected columns: `GroupID`, `GroupLevel`,
+#'   `Numerator`, `Denominator`, and `Metric`. For more details see the Data
+#'   Model vignette: `vignette("DataModel", package = "gsm")`. For this
+#'   function, `dfTransformed` should typically be created using
+#'   [Transform_Rate()].
+#' @param vThreshold `numeric` upper and lower boundaries in residual space.
+#'   Should be identical to the thresholds used AE_Assess().
 #' @param nStep `numeric` step size of imputed bounds.
 #'
-#' @return `data.frame` containing predicted boundary values with upper and lower bounds across the
-#' range of observed values.
+#' @return `data.frame` containing predicted boundary values with upper and
+#'   lower bounds across the range of observed values.
 #'
 #' @examples
 #' dfTransformed <- Transform_Rate(analyticsInput)

--- a/R/Report_MetricTable.R
+++ b/R/Report_MetricTable.R
@@ -2,13 +2,18 @@
 #'
 #' @description `r lifecycle::badge("stable")`
 #'
-#' This function generates a summary table for a report by joining the provided
-#' results data frame with the site-level metadata from dfGroups. It then
-#' filters and arranges the data based on certain conditions and displays the
-#' result in a datatable.
+#'   This function generates a summary table for a report by joining the
+#'   provided results data frame with the site-level metadata from dfGroups. It
+#'   then filters and arranges the data based on certain conditions and displays
+#'   the result in a datatable.
 #'
 #' @inheritParams shared-params
-#' @param dfResults `r gloss_param("dfResults")` `r gloss_extra("dfResults_filtered")`
+#' @param dfResults `data.frame` A stacked summary of analysis pipeline output.
+#'   Created by passing a list of results returned by [Summarize()] to
+#'   [BindResults()]. Expected columns: `GroupID`, `GroupLevel`, `Numerator`,
+#'   `Denominator`, `Metric`, `Score`, `Flag`, `MetricID`, `StudyID`,
+#'   `SnapshotDate`. For this function, `dfResults` must be filtered to a single
+#'   KRI (`MetricID`).
 #' @param strGroupLevel  group level for the table
 #' @param strGroupDetailsParams one or more parameters from dfGroups to be added
 #'   as columns in the table

--- a/R/aaa-shared.R
+++ b/R/aaa-shared.R
@@ -1,27 +1,41 @@
 .le <- new.env(parent = emptyenv())
 
-gloss_param <- function(param) {
-  param_def <- yaml::read_yaml(paste0("man/glossary/", param, ".yaml"))
-  glue::glue("`{param_def$class}` {param_def$definition}")
-}
-gloss_extra <- function(x) {
-  readLines(glue::glue("man/glossary/{x}.Rmd"))
-}
-
 #' Parameters used in multiple functions
 #'
-#' @description
-#' Reused parameter definitions are gathered here for easier usage. Edit the
-#' definitions in `man/glossary/{term}.Rmd` (one file per term).
+#' @description Reused parameter definitions are gathered here for easier usage.
 #'
-#' @param dfMetrics `r gloss_param("dfMetrics")`
-#' @param dfResults `r gloss_param("dfResults")`
-#' @param dfBounds `r gloss_param("dfBounds")`
-#' @param dfGroups `r gloss_param("dfGroups")`
-#' @param dfInput `r gloss_param("dfInput")`
-#' @param lMetric `r gloss_param("lMetric")`
-#' @param lParamLabels `r gloss_param("lParamLabels")`
-#' @param bDebug `r gloss_param("bDebug")`
+#' @param dfMetrics `data.frame` Metric-specific metadata for use in charts and
+#'   reporting. Created by passing an `lWorkflow` object to [MakeMetric()].
+#'   Expected columns: `File`, `MetricID`, `Group`, `Abbreviation`, `Metric`,
+#'   `Numerator`, `Denominator`, `Model`, `Score`, and `Threshold`. For more
+#'   details see the Data Model vignette: `vignette("DataModel", package =
+#'   "gsm")`.
+#' @param dfResults `data.frame` A stacked summary of analysis pipeline output.
+#'   Created by passing a list of results returned by [Summarize()] to
+#'   [BindResults()]. Expected columns: `GroupID`, `GroupLevel`, `Numerator`,
+#'   `Denominator`, `Metric`, `Score`, `Flag`, `MetricID`, `StudyID`,
+#'   `SnapshotDate`.
+#' @param dfBounds `data.frame` Set of predicted percentages/rates and upper-
+#'   and lower-bounds across the full range of sample sizes/total exposure
+#'   values for reporting. Created by passing `dfResults` and `dfMetrics` to
+#'   [MakeBounds()]. Expected columns: `Threshold`, `Denominator`, `Numerator`,
+#'   `Metric`, `MetricID`, `StudyID`, `SnapshotDate`.
+#' @param dfGroups `data.frame` Group-level metadata dictionary. Created by
+#'   passing CTMS site and study data to [MakeLongMeta()]. Expected columns:
+#'   `GroupID`, `GroupLevel`, `Param`, `Value`.
+#' @param dfInput `data.frame` Input data with one record per subject. Created
+#'   by passing Raw+ data into [Input_Rate()]. Expected columns: `GroupID`,
+#'   `GroupLevel`, `Numerator`, `Denominator` and/or columns specified in
+#'   `strCountCol` and `strGroupCol`.
+#' @param lMetric `list` Metric-specific metadata for use in charts and
+#'   reporting. Created by passing an `lWorkflow` object to [MakeMetric()] and
+#'   turing it into a list. Expected columns: `File`,`MetricID`, `Group`,
+#'   `Abbreviation`, `Metric`, `Numerator`, `Denominator`, `Model`, `Score`, and
+#'   `strThreshold`. For more details see the Data Model vignette:
+#'   `vignette("DataModel", package = "gsm")`.
+#' @param lParamLabels `list` Labels for parameters, with the parameters as
+#'   names, and the label as value.
+#' @param bDebug `logical` Print debug messages? Default: `FALSE`.
 #'
 #'
 #' @name shared-params

--- a/gsm.Rproj
+++ b/gsm.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 21144401-9f3b-4a66-a10d-289142b4e49d
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/Analyze_Fisher.Rd
+++ b/man/Analyze_Fisher.Rd
@@ -7,8 +7,12 @@
 Analyze_Fisher(dfTransformed, strOutcome = "Numerator")
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Rate]{Transform_Rate()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
 \item{strOutcome}{\code{character} required, name of column in \code{dfTransformed}
 dataset to perform Fisher's exact test on. Default is "Numerator".}

--- a/man/Analyze_Identity.Rd
+++ b/man/Analyze_Identity.Rd
@@ -7,18 +7,24 @@
 Analyze_Identity(dfTransformed, strValueCol = "Metric")
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Count]{Transform_Count()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Count]{Transform_Count()}}.}
 
 \item{strValueCol}{\code{character} Name of column that will be copied as \code{Score}}
 }
 \value{
-\code{data.frame} with one row per site with columns: GroupID, TotalCount, Metric, and Score.
+\code{data.frame} with one row per site with columns: GroupID, TotalCount,
+Metric, and Score.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Used in the data pipeline between \code{Transform} and \code{Flag} to rename KRI and Score columns.
+Used in the data pipeline between \code{Transform} and \code{Flag} to rename KRI and
+Score columns.
 
 More information can be found in \href{https://gilead-biostats.github.io/gsm/articles/KRI\%20Method.html#the-identity-method}{The Identity Method}
 of the KRI Method vignette.

--- a/man/Analyze_NormalApprox.Rd
+++ b/man/Analyze_NormalApprox.Rd
@@ -7,8 +7,12 @@
 Analyze_NormalApprox(dfTransformed, strType = "binary")
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Rate]{Transform_Rate()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
 \item{strType}{\code{character} Statistical outcome type. Valid values:
 \itemize{
@@ -17,21 +21,24 @@ For this function, \code{dfTransformed} should typically be created using \code{
 }}
 }
 \value{
-\code{data.frame} with one row per site with columns: GroupID, Numerator, Denominator, Metric, OverallMetric, Factor, and Score.
+\code{data.frame} with one row per site with columns: GroupID, Numerator,
+Denominator, Metric, OverallMetric, Factor, and Score.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Creates analysis results data for percentage/rate data using funnel plot method with normal approximation.
+Creates analysis results data for percentage/rate data using funnel plot
+method with normal approximation.
 
 More information can be found in \href{https://gilead-biostats.github.io/gsm/articles/KRI\%20Method.html#the-normal-approximation-method}{The Normal Approximation Method}
 of the KRI Method vignette.
 }
 \section{Statistical Methods}{
-
-This function applies funnel plots using asymptotic limits based on the normal approximation of a binomial distribution for
-the binary outcome, or normal approximation of a Poisson distribution for the rate outcome with volume (the sample sizes
-or total exposure of the sites) to assess data quality and safety.
+ This function applies funnel plots using
+asymptotic limits based on the normal approximation of a binomial
+distribution for the binary outcome, or normal approximation of a Poisson
+distribution for the rate outcome with volume (the sample sizes or total
+exposure of the sites) to assess data quality and safety.
 }
 
 \examples{

--- a/man/Analyze_NormalApprox_PredictBounds.Rd
+++ b/man/Analyze_NormalApprox_PredictBounds.Rd
@@ -12,11 +12,16 @@ Analyze_NormalApprox_PredictBounds(
 )
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Rate]{Transform_Rate()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
-\item{vThreshold}{\code{numeric} upper and lower boundaries based on standard deviation. Should be identical to
-the thresholds used in \verb{*_Assess()} functions.}
+\item{vThreshold}{\code{numeric} upper and lower boundaries based on standard
+deviation. Should be identical to the thresholds used in \verb{*_Assess()}
+functions.}
 
 \item{strType}{\code{character} Statistical method. Valid values:
 \itemize{
@@ -27,20 +32,22 @@ the thresholds used in \verb{*_Assess()} functions.}
 \item{nStep}{\code{numeric} step size of imputed bounds.}
 }
 \value{
-\code{data.frame} containing predicted boundary values with upper and lower bounds across the
-range of observed values.
+\code{data.frame} containing predicted boundary values with upper and
+lower bounds across the range of observed values.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Applies a funnel plot analysis with normal approximation to site-level data, and then calculates predicted
-percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values.
+Applies a funnel plot analysis with normal approximation to site-level data,
+and then calculates predicted percentages/rates and upper- and lower-bounds
+across the full range of sample sizes/total exposure values.
 }
 \section{Statistical Methods}{
-
-This function applies a funnel plot analysis with normal approximation to site-level data and then calculates
-predicted percentages/rates and upper- and lower- bounds (funnels) based on the standard deviation from the mean
-across the full range of sample sizes/total exposure values.
+ This function applies a funnel plot analysis
+with normal approximation to site-level data and then calculates predicted
+percentages/rates and upper- and lower- bounds (funnels) based on the
+standard deviation from the mean across the full range of sample
+sizes/total exposure values.
 }
 
 \examples{

--- a/man/Analyze_Poisson.Rd
+++ b/man/Analyze_Poisson.Rd
@@ -7,17 +7,23 @@
 Analyze_Poisson(dfTransformed)
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Rate]{Transform_Rate()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Rate]{Transform_Rate()}}.}
 }
 \value{
-\code{data.frame} with one row per site with columns: GroupID, Numerator, Denominator, Metric, Score, and PredictedCount.
+\code{data.frame} with one row per site with columns: GroupID, Numerator,
+Denominator, Metric, Score, and PredictedCount.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 }
 \details{
-Fits a Poisson model to site-level data and adds columns capturing Residual and Predicted Count for each site.
+Fits a Poisson model to site-level data and adds columns capturing
+Residual and Predicted Count for each site.
 
 More information can be found in \href{https://gilead-biostats.github.io/gsm/articles/KRI\%20Method.html#the-poisson-regression-method}{The Poisson Regression Method}
 of the KRI Method vignette.
@@ -25,9 +31,11 @@ of the KRI Method vignette.
 \section{Statistical Methods}{
 
 
-This function fits a Poisson model to site-level data and then calculates residuals for each site.
-The Poisson model is run using standard methods in the \code{stats} package by fitting a \code{glm} model with family
-set to \code{poisson} using a "log" link. Site-level residuals are calculated using \code{stats::predict.glm} via \code{broom::augment}.
+This function fits a Poisson model to site-level data and then calculates
+residuals for each site. The Poisson model is run using standard methods in
+the \code{stats} package by fitting a \code{glm} model with family set to \code{poisson}
+using a "log" link. Site-level residuals are calculated using
+\code{stats::predict.glm} via \code{broom::augment}.
 }
 
 \examples{

--- a/man/Analyze_Poisson_PredictBounds.Rd
+++ b/man/Analyze_Poisson_PredictBounds.Rd
@@ -11,30 +11,36 @@ Analyze_Poisson_PredictBounds(
 )
 }
 \arguments{
-\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should have one record per site with expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.
-For this function, \code{dfTransformed} should typically be created using \code{\link[=Transform_Rate]{Transform_Rate()}}.}
+\item{dfTransformed}{\code{data.frame} Transformed data for analysis. Data should
+have one record per site with expected columns: \code{GroupID}, \code{GroupLevel},
+\code{Numerator}, \code{Denominator}, and \code{Metric}. For more details see the Data
+Model vignette: \code{vignette("DataModel", package = "gsm")}. For this
+function, \code{dfTransformed} should typically be created using
+\code{\link[=Transform_Rate]{Transform_Rate()}}.}
 
-\item{vThreshold}{\code{numeric} upper and lower boundaries in residual space. Should be identical to
-the thresholds used AE_Assess().}
+\item{vThreshold}{\code{numeric} upper and lower boundaries in residual space.
+Should be identical to the thresholds used AE_Assess().}
 
 \item{nStep}{\code{numeric} step size of imputed bounds.}
 }
 \value{
-\code{data.frame} containing predicted boundary values with upper and lower bounds across the
-range of observed values.
+\code{data.frame} containing predicted boundary values with upper and
+lower bounds across the range of observed values.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-Fits a Poisson model to site-level data and then calculates predicted count values and upper- and
-lower- bounds for across the full range of exposure values.
+Fits a Poisson model to site-level data and then calculates predicted count
+values and upper- and lower- bounds for across the full range of exposure
+values.
 }
 \section{Statistical Methods}{
-
-This function fits a Poisson model to site-level data and then calculates residuals for each
-site. The Poisson model is run using standard methods in the \code{stats} package by fitting a \code{glm}
-model with family set to \code{poisson} using a "log" link. Upper and lower boundary values are then
-calculated using the method described here TODO: Add link.
+ This function fits a Poisson model to
+site-level data and then calculates residuals for each site. The Poisson
+model is run using standard methods in the \code{stats} package by fitting a
+\code{glm} model with family set to \code{poisson} using a "log" link. Upper and
+lower boundary values are then calculated using the method described here
+TODO: Add link.
 }
 
 \examples{

--- a/man/MakeBounds.Rd
+++ b/man/MakeBounds.Rd
@@ -13,9 +13,17 @@ MakeBounds(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strMetrics}{Character vector of \code{MetricID}s to include in \code{dfBounds}.
 All unique values from \code{dfResults$MetricID} used by default.}

--- a/man/MakeCharts.Rd
+++ b/man/MakeCharts.Rd
@@ -7,13 +7,27 @@
 MakeCharts(dfResults, dfBounds, dfGroups, dfMetrics, bDebug = FALSE)
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to \code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator}, \code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper-
+and lower-bounds across the full range of sample sizes/total exposure
+values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to
+\code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator},
+\code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{bDebug}{\code{logical} Print debug messages? Default: \code{FALSE}.}
 }

--- a/man/MakeMetricTable.Rd
+++ b/man/MakeMetricTable.Rd
@@ -13,9 +13,16 @@ MakeMetricTable(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}. For this function, \code{dfResults} must be filtered to a single KRI (\code{MetricID}).}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}. For this function, \code{dfResults} must be filtered to a single
+KRI (\code{MetricID}).}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{strGroupLevel}{group level for the table}
 

--- a/man/MakeParamLabels.Rd
+++ b/man/MakeParamLabels.Rd
@@ -10,9 +10,12 @@ MakeParamLabels(dfGroups, lParamLabels = NULL)
 MakeParamLabelsList(chrParams, lParamLabels = NULL)
 }
 \arguments{
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{lParamLabels}{\code{list} Labels for parameters, with the parameters as names, and the label as value.}
+\item{lParamLabels}{\code{list} Labels for parameters, with the parameters as
+names, and the label as value.}
 
 \item{chrParams}{A character vector of parameters, or a list that can be
 coerced to a character vector.}

--- a/man/MakeStudyInfo.Rd
+++ b/man/MakeStudyInfo.Rd
@@ -7,7 +7,9 @@
 MakeStudyInfo(dfGroups, lStudyLabels = NULL, lStudy = deprecated())
 }
 \arguments{
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{lStudyLabels}{\code{list} A list containing study labels. Default is NULL.}
 

--- a/man/MakeWideGroups.Rd
+++ b/man/MakeWideGroups.Rd
@@ -7,7 +7,9 @@
 MakeWideGroups(dfGroups, strGroupLevel)
 }
 \arguments{
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{strGroupLevel}{A string specifying the group level; used to filter
 dfGroups$GroupLevel.}

--- a/man/Report_FlagOverTime.Rd
+++ b/man/Report_FlagOverTime.Rd
@@ -11,9 +11,17 @@ Report_FlagOverTime(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strGroupLevel}{A string specifying the group type.}
 }

--- a/man/Report_KRI.Rd
+++ b/man/Report_KRI.Rd
@@ -16,11 +16,21 @@ Report_KRI(
 \arguments{
 \item{lCharts}{A list of charts to include in the report.}
 
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strOutputDir}{The output directory path for the generated report. If not provided,
 the report will be saved in the current working directory.}

--- a/man/Report_MetricTable.Rd
+++ b/man/Report_MetricTable.Rd
@@ -13,9 +13,16 @@ Report_MetricTable(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}. For this function, \code{dfResults} must be filtered to a single KRI (\code{MetricID}).}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}. For this function, \code{dfResults} must be filtered to a single
+KRI (\code{MetricID}).}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{strGroupLevel}{group level for the table}
 
@@ -31,10 +38,10 @@ A \code{\link[gt:gt]{gt::gt()}} containing the summary table.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
-This function generates a summary table for a report by joining the provided
-results data frame with the site-level metadata from dfGroups. It then
-filters and arranges the data based on certain conditions and displays the
-result in a datatable.
+This function generates a summary table for a report by joining the
+provided results data frame with the site-level metadata from dfGroups. It
+then filters and arranges the data based on certain conditions and displays
+the result in a datatable.
 }
 \examples{
 # site-level report

--- a/man/Report_OverviewText.Rd
+++ b/man/Report_OverviewText.Rd
@@ -9,7 +9,11 @@ Report_OverviewText(lSetup, dfResults, lStudy)
 \arguments{
 \item{lSetup}{\code{list} that is produced by \code{Report_StudyInfo()}.}
 
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
 \item{lStudy}{\code{list} contains study-level metadata.}
 }

--- a/man/Report_Setup.Rd
+++ b/man/Report_Setup.Rd
@@ -7,11 +7,21 @@
 Report_Setup(dfGroups = NULL, dfMetrics = NULL, dfResults = NULL)
 }
 \arguments{
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 }
 \value{
 \code{list} with the following elements:

--- a/man/Report_StudyInfo.Rd
+++ b/man/Report_StudyInfo.Rd
@@ -13,7 +13,9 @@ Report_StudyInfo(
 )
 }
 \arguments{
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{lStudyLabels}{\code{list} A list containing study labels. Default is NULL.}
 

--- a/man/Transform_Count.Rd
+++ b/man/Transform_Count.Rd
@@ -7,7 +7,10 @@
 Transform_Count(dfInput, strCountCol, strGroupCol = "GroupID")
 }
 \arguments{
-\item{dfInput}{\code{data.frame} Input data with one record per subject. Created by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in \code{strCountCol} and \code{strGroupCol}.}
+\item{dfInput}{\code{data.frame} Input data with one record per subject. Created
+by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID},
+\code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in
+\code{strCountCol} and \code{strGroupCol}.}
 
 \item{strCountCol}{Required. Numerical or logical. Column to be counted.}
 

--- a/man/Transform_Rate.Rd
+++ b/man/Transform_Rate.Rd
@@ -11,7 +11,10 @@ Transform_Rate(
 )
 }
 \arguments{
-\item{dfInput}{\code{data.frame} Input data with one record per subject. Created by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in \code{strCountCol} and \code{strGroupCol}.}
+\item{dfInput}{\code{data.frame} Input data with one record per subject. Created
+by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID},
+\code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in
+\code{strCountCol} and \code{strGroupCol}.}
 
 \item{strNumeratorCol}{\code{string} Column to be counted. Defaults to "Numerator".}
 

--- a/man/Visualize_Metric.Rd
+++ b/man/Visualize_Metric.Rd
@@ -15,13 +15,27 @@ Visualize_Metric(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to \code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator}, \code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper-
+and lower-bounds across the full range of sample sizes/total exposure
+values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to
+\code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator},
+\code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strMetricID}{\code{character} MetricID to subset the data.}
 

--- a/man/Visualize_Scatter.Rd
+++ b/man/Visualize_Scatter.Rd
@@ -14,9 +14,17 @@ Visualize_Scatter(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to \code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator}, \code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper-
+and lower-bounds across the full range of sample sizes/total exposure
+values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to
+\code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator},
+\code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
 
 \item{strGroupCol}{\code{character} name of stratification column for facet wrap Default: \code{NULL}}
 

--- a/man/Visualize_Score.Rd
+++ b/man/Visualize_Score.Rd
@@ -13,7 +13,11 @@ Visualize_Score(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
 \item{vThreshold}{\code{numeric} Threshold specification, a vector of length 2 that defaults to NULL.}
 

--- a/man/Widget_BarChart.Rd
+++ b/man/Widget_BarChart.Rd
@@ -16,11 +16,22 @@ Widget_BarChart(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{lMetric}{\code{list} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{strThreshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{lMetric}{\code{list} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and
+turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group},
+\code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and
+\code{strThreshold}. For more details see the Data Model vignette:
+\code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{vThreshold}{\code{numeric} Threshold values.}
 

--- a/man/Widget_FlagOverTime-shiny.Rd
+++ b/man/Widget_FlagOverTime-shiny.Rd
@@ -21,9 +21,17 @@ renderWidget_FlagOverTime(
 \code{'400px'}, \code{'auto'}) or a number, which will be coerced to a
 string and have \code{'px'} appended.}
 
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strGroupLevel}{\code{character} Value for the group level. Default: "Site".}
 }

--- a/man/Widget_FlagOverTime.Rd
+++ b/man/Widget_FlagOverTime.Rd
@@ -14,9 +14,17 @@ Widget_FlagOverTime(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
 \item{strGroupLevel}{\code{character} Value for the group level. Default: "Site".}
 

--- a/man/Widget_GroupOverview.Rd
+++ b/man/Widget_GroupOverview.Rd
@@ -15,11 +15,21 @@ Widget_GroupOverview(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{strGroupLevel}{\code{character} Value for the group level. Default: NULL and taken from \code{dfMetrics$GroupLevel} if available.}
 

--- a/man/Widget_ScatterPlot.Rd
+++ b/man/Widget_ScatterPlot.Rd
@@ -15,13 +15,28 @@ Widget_ScatterPlot(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{lMetric}{\code{list} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{strThreshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{lMetric}{\code{list} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and
+turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group},
+\code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and
+\code{strThreshold}. For more details see the Data Model vignette:
+\code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to \code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator}, \code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper-
+and lower-bounds across the full range of sample sizes/total exposure
+values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to
+\code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator},
+\code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
 
 \item{bAddGroupSelect}{\code{logical} Add a dropdown to highlight sites? Default: \code{TRUE}.}
 

--- a/man/Widget_TimeSeries.Rd
+++ b/man/Widget_TimeSeries.Rd
@@ -16,11 +16,22 @@ Widget_TimeSeries(
 )
 }
 \arguments{
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{lMetric}{\code{list} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{strThreshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{lMetric}{\code{list} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and
+turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group},
+\code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and
+\code{strThreshold}. For more details see the Data Model vignette:
+\code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
 \item{vThreshold}{\code{numeric} Threshold value(s).}
 

--- a/man/shared-params.Rd
+++ b/man/shared-params.Rd
@@ -4,24 +4,46 @@
 \alias{shared-params}
 \title{Parameters used in multiple functions}
 \arguments{
-\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}. Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{dfMetrics}{\code{data.frame} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}}.
+Expected columns: \code{File}, \code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric},
+\code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{Threshold}. For more
+details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
 
-\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output. Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
+Created by passing a list of results returned by \code{\link[=Summarize]{Summarize()}} to
+\code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
+\code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
+\code{SnapshotDate}.}
 
-\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper- and lower-bounds across the full range of sample sizes/total exposure values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to \code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator}, \code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
+\item{dfBounds}{\code{data.frame} Set of predicted percentages/rates and upper-
+and lower-bounds across the full range of sample sizes/total exposure
+values for reporting. Created by passing \code{dfResults} and \code{dfMetrics} to
+\code{\link[=MakeBounds]{MakeBounds()}}. Expected columns: \code{Threshold}, \code{Denominator}, \code{Numerator},
+\code{Metric}, \code{MetricID}, \code{StudyID}, \code{SnapshotDate}.}
 
-\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
+\item{dfGroups}{\code{data.frame} Group-level metadata dictionary. Created by
+passing CTMS site and study data to \code{\link[=MakeLongMeta]{MakeLongMeta()}}. Expected columns:
+\code{GroupID}, \code{GroupLevel}, \code{Param}, \code{Value}.}
 
-\item{dfInput}{\code{data.frame} Input data with one record per subject. Created by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in \code{strCountCol} and \code{strGroupCol}.}
+\item{dfInput}{\code{data.frame} Input data with one record per subject. Created
+by passing Raw+ data into \code{\link[=Input_Rate]{Input_Rate()}}. Expected columns: \code{GroupID},
+\code{GroupLevel}, \code{Numerator}, \code{Denominator} and/or columns specified in
+\code{strCountCol} and \code{strGroupCol}.}
 
-\item{lMetric}{\code{list} Metric-specific metadata for use in charts and reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group}, \code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and \code{strThreshold}. For more details see the Data Model vignette: \code{vignette("DataModel", package = "gsm")}.}
+\item{lMetric}{\code{list} Metric-specific metadata for use in charts and
+reporting. Created by passing an \code{lWorkflow} object to \code{\link[=MakeMetric]{MakeMetric()}} and
+turing it into a list. Expected columns: \code{File},\code{MetricID}, \code{Group},
+\code{Abbreviation}, \code{Metric}, \code{Numerator}, \code{Denominator}, \code{Model}, \code{Score}, and
+\code{strThreshold}. For more details see the Data Model vignette:
+\code{vignette("DataModel", package = "gsm")}.}
 
-\item{lParamLabels}{\code{list} Labels for parameters, with the parameters as names, and the label as value.}
+\item{lParamLabels}{\code{list} Labels for parameters, with the parameters as
+names, and the label as value.}
 
 \item{bDebug}{\code{logical} Print debug messages? Default: \code{FALSE}.}
 }
 \description{
-Reused parameter definitions are gathered here for easier usage. Edit the
-definitions in \verb{man/glossary/\{term\}.Rmd} (one file per term).
+Reused parameter definitions are gathered here for easier usage.
 }
 \keyword{internal}


### PR DESCRIPTION
## Overview
This idea never came together fully, so let's simplify.

You still need `R/aaa-shared.R` in each package that splits off from gsm, but then ideally we should delete any parameters that aren't used from there. Search for `gloss_param` in your repo to find other place where this was used, and copy/paste the equivalent from here.